### PR TITLE
Build a CSV list of existing help content

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,3 +14,13 @@ lazy val root = (project in file("."))
       jsoup
     )
   )
+
+// Sub-project to import content into SF Knowledge
+lazy val legacyContentImport = (project in file("legacy-content-import"))
+  .settings(
+    name := "legacy-content-import",
+    libraryDependencies ++= Seq(
+      http,
+      upickle
+    )
+  )

--- a/legacy-content-import/src/main/scala/legacycontentimport/Article.scala
+++ b/legacy-content-import/src/main/scala/legacycontentimport/Article.scala
@@ -1,0 +1,47 @@
+package legacycontentimport
+
+import scalaj.http.Http
+
+import java.net.URI
+import java.time.Instant
+import scala.annotation.tailrec
+import scala.util.{Failure, Success, Try}
+
+case class Article(url: URI, title: String, publicationDate: Instant)
+
+object Article {
+
+  def fromCapiHelpSection(capiDomain: String, capiKey: String): Seq[Article] = {
+
+    val fetch = fromCapiHelpSectionPage(capiDomain, capiKey) _
+
+    @tailrec
+    def go(pageIndex: Int, acc: Seq[Article]): Seq[Article] =
+      Try(fetch(pageIndex)) match {
+        case Failure(_)        => acc
+        case Success(articles) => go(pageIndex + 1, acc ++ articles)
+      }
+
+    go(0, Nil)
+  }
+
+  private def fromCapiHelpSectionPage(capiDomain: String, capiKey: String)(pageIndex: Int): Seq[Article] = {
+
+    def toArticle(result: ujson.Value): Article = Article(
+      title = result("webTitle").str,
+      url = new URI(result("webUrl").str),
+      publicationDate = Instant.parse(result("webPublicationDate").str)
+    )
+
+    val response =
+      Http(s"https://$capiDomain/search")
+        .param("api-key", capiKey)
+        .param("tag", "type/article")
+        .param("section", "help")
+        .param("page", (pageIndex + 1).toString)
+        .asString
+
+    val results = ujson.read(response.body)("response")("results")
+    results.arr.toList.map(toArticle)
+  }
+}

--- a/legacy-content-import/src/main/scala/legacycontentimport/Main.scala
+++ b/legacy-content-import/src/main/scala/legacycontentimport/Main.scala
@@ -7,6 +7,6 @@ object Main extends App {
 
   val articles = Article.fromCapiHelpSection(capiDomain, capiKey)
   articles foreach { article =>
-    println(s"${article.url},${article.title},${article.publicationDate}")
+    println(s"""${article.url},"${article.title.replace("\"", "'")}",${article.publicationDate}""")
   }
 }

--- a/legacy-content-import/src/main/scala/legacycontentimport/Main.scala
+++ b/legacy-content-import/src/main/scala/legacycontentimport/Main.scala
@@ -1,0 +1,12 @@
+package legacycontentimport
+
+object Main extends App {
+
+  val capiKey = args(0)
+  val capiDomain = args(1)
+
+  val articles = Article.fromCapiHelpSection(capiDomain, capiKey)
+  articles foreach { article =>
+    println(s"${article.url},${article.title},${article.publicationDate}")
+  }
+}


### PR DESCRIPTION
This is to generate a spreadsheet of existing content so that it can be used for more easily batch-setting topics.
Then we can use this to import into SF Knowledge.
