### PR TITLE
Add tags to CSV list

### DIFF
--- a/legacy-content-import/src/main/scala/legacycontentimport/Article.scala
+++ b/legacy-content-import/src/main/scala/legacycontentimport/Article.scala
@@ -41,8 +41,9 @@ object Article {
 
       val tagsToInclude = result("tags").arr.toList.filterNot(tag => excludedTags.contains(tag("id").str))
 
-      def tagsOfType(typeName: String) =
-        tagsToInclude.filter(tag => tag("type").str == typeName).map(_("webTitle").str)
+      def tagsOfType(typeName: String) = tagsToInclude collect {
+        case tag if tag("type").str == typeName => tag("webTitle").str
+      }
 
       Article(
         title = result("webTitle").str,

--- a/legacy-content-import/src/main/scala/legacycontentimport/Article.scala
+++ b/legacy-content-import/src/main/scala/legacycontentimport/Article.scala
@@ -7,9 +7,19 @@ import java.time.Instant
 import scala.annotation.tailrec
 import scala.util.{Failure, Success, Try}
 
-case class Article(url: URI, title: String, publicationDate: Instant)
+case class Article(
+    url: URI,
+    title: String,
+    publicationDate: Instant,
+    keywords: Seq[String],
+    series: Option[String],
+    tone: Option[String],
+    blog: Option[String]
+)
 
 object Article {
+
+  val excludedTags = Seq("help/help", "tone/help")
 
   def fromCapiHelpSection(capiDomain: String, capiKey: String): Seq[Article] = {
 
@@ -27,17 +37,30 @@ object Article {
 
   private def fromCapiHelpSectionPage(capiDomain: String, capiKey: String)(pageIndex: Int): Seq[Article] = {
 
-    def toArticle(result: ujson.Value): Article = Article(
-      title = result("webTitle").str,
-      url = new URI(result("webUrl").str),
-      publicationDate = Instant.parse(result("webPublicationDate").str)
-    )
+    def toArticle(result: ujson.Value): Article = {
+
+      val tagsToInclude = result("tags").arr.toList.filterNot(tag => excludedTags.contains(tag("id").str))
+
+      def tagsOfType(typeName: String) =
+        tagsToInclude.filter(tag => tag("type").str == typeName).map(_("webTitle").str)
+
+      Article(
+        title = result("webTitle").str,
+        url = new URI(result("webUrl").str),
+        publicationDate = Instant.parse(result("webPublicationDate").str),
+        keywords = tagsOfType("keyword").sorted,
+        series = tagsOfType("series").headOption,
+        tone = tagsOfType("tone").headOption,
+        blog = tagsOfType("blog").headOption
+      )
+    }
 
     val response =
       Http(s"https://$capiDomain/search")
         .param("api-key", capiKey)
         .param("tag", "type/article")
         .param("section", "help")
+        .param("show-tags", "keyword,series,tone,blog")
         .param("page", (pageIndex + 1).toString)
         .asString
 

--- a/legacy-content-import/src/main/scala/legacycontentimport/Main.scala
+++ b/legacy-content-import/src/main/scala/legacycontentimport/Main.scala
@@ -7,7 +7,15 @@ object Main extends App {
 
   val articles = Article.fromCapiHelpSection(capiDomain, capiKey)
   articles foreach { article =>
-    println(s"""${article.url},"${article.title.replace("\"", "'")}",${article.publicationDate},"${article.keywords
-      .mkString(", ")}","${article.series.mkString}","${article.tone.mkString}","${article.blog.mkString}"""")
+    val fields = Seq(
+      article.url,
+      article.title.replace("\"", "'"),
+      article.publicationDate,
+      article.keywords.mkString(", "),
+      article.series.mkString,
+      article.tone.mkString,
+      article.blog.mkString
+    )
+    println(fields.mkString("\"", "\",\"", "\""))
   }
 }

--- a/legacy-content-import/src/main/scala/legacycontentimport/Main.scala
+++ b/legacy-content-import/src/main/scala/legacycontentimport/Main.scala
@@ -7,6 +7,7 @@ object Main extends App {
 
   val articles = Article.fromCapiHelpSection(capiDomain, capiKey)
   articles foreach { article =>
-    println(s"""${article.url},"${article.title.replace("\"", "'")}",${article.publicationDate}""")
+    println(s"""${article.url},"${article.title.replace("\"", "'")}",${article.publicationDate},"${article.keywords
+      .mkString(", ")}","${article.series.mkString}","${article.tone.mkString}","${article.blog.mkString}"""")
   }
 }


### PR DESCRIPTION
This is to audit the content of the `help` section.
This adds columns for keywords, series, tone and blog to each article.

See also #3. 
