### PR TITLE
Fetch paginated results without relying on exceptions

### DIFF
--- a/legacy-content-import/src/main/scala/legacycontentimport/Article.scala
+++ b/legacy-content-import/src/main/scala/legacycontentimport/Article.scala
@@ -4,8 +4,6 @@ import scalaj.http.Http
 
 import java.net.URI
 import java.time.Instant
-import scala.annotation.tailrec
-import scala.util.{Failure, Success, Try}
 
 case class Article(
     url: URI,
@@ -19,53 +17,59 @@ case class Article(
 
 object Article {
 
-  val excludedTags = Seq("help/help", "tone/help")
+  private val excludedTags = Seq("help/help", "tone/help")
+
+  private case class ArticlesAndPageCount(articles: Seq[Article], pageCount: Int)
 
   def fromCapiHelpSection(capiDomain: String, capiKey: String): Seq[Article] = {
-
-    val fetch = fromCapiHelpSectionPage(capiDomain, capiKey) _
-
-    @tailrec
-    def go(pageIndex: Int, acc: Seq[Article]): Seq[Article] =
-      Try(fetch(pageIndex)) match {
-        case Failure(_)        => acc
-        case Success(articles) => go(pageIndex + 1, acc ++ articles)
-      }
-
-    go(0, Nil)
+    val fetch = pageFromCapiHelpSection(capiDomain, capiKey) _
+    val articlesAndPageCount = firstPageFromCapiHelpSection(capiDomain, capiKey)
+    val pageIndices = 1 until articlesAndPageCount.pageCount
+    val firstPageArticles = articlesAndPageCount.articles
+    pageIndices.foldLeft(firstPageArticles)((acc, pageIndex) => acc ++ fetch(pageIndex))
   }
 
-  private def fromCapiHelpSectionPage(capiDomain: String, capiKey: String)(pageIndex: Int): Seq[Article] = {
+  private def firstPageFromCapiHelpSection(capiDomain: String, capiKey: String): ArticlesAndPageCount = {
+    val capiResponse = capiRequest(capiDomain, capiKey).asString
+    val response = ujson.read(capiResponse.body)("response")
+    ArticlesAndPageCount(
+      articles = response("results").arr.toList.map(toArticle),
+      pageCount = response("pages").num.toInt
+    )
+  }
 
-    def toArticle(result: ujson.Value): Article = {
-
-      val tagsToInclude = result("tags").arr.toList.filterNot(tag => excludedTags.contains(tag("id").str))
-
-      def tagsOfType(typeName: String) = tagsToInclude collect {
-        case tag if tag("type").str == typeName => tag("webTitle").str
-      }
-
-      Article(
-        title = result("webTitle").str,
-        url = new URI(result("webUrl").str),
-        publicationDate = Instant.parse(result("webPublicationDate").str),
-        keywords = tagsOfType("keyword").sorted,
-        series = tagsOfType("series").headOption,
-        tone = tagsOfType("tone").headOption,
-        blog = tagsOfType("blog").headOption
-      )
-    }
-
-    val response =
-      Http(s"https://$capiDomain/search")
-        .param("api-key", capiKey)
-        .param("tag", "type/article")
-        .param("section", "help")
-        .param("show-tags", "keyword,series,tone,blog")
+  private def pageFromCapiHelpSection(capiDomain: String, capiKey: String)(pageIndex: Int): Seq[Article] = {
+    val capiResponse =
+      capiRequest(capiDomain, capiKey)
         .param("page", (pageIndex + 1).toString)
         .asString
-
-    val results = ujson.read(response.body)("response")("results")
+    val results = ujson.read(capiResponse.body)("response")("results")
     results.arr.toList.map(toArticle)
+  }
+
+  private def capiRequest(capiDomain: String, capiKey: String) =
+    Http(s"https://$capiDomain/search")
+      .param("api-key", capiKey)
+      .param("tag", "type/article")
+      .param("section", "help")
+      .param("show-tags", "keyword,series,tone,blog")
+
+  private def toArticle(result: ujson.Value): Article = {
+
+    val tagsToInclude = result("tags").arr.toList.filterNot(tag => excludedTags.contains(tag("id").str))
+
+    def tagsOfType(typeName: String) = tagsToInclude collect {
+      case tag if tag("type").str == typeName => tag("webTitle").str
+    }
+
+    Article(
+      title = result("webTitle").str,
+      url = new URI(result("webUrl").str),
+      publicationDate = Instant.parse(result("webPublicationDate").str),
+      keywords = tagsOfType("keyword").sorted,
+      series = tagsOfType("series").headOption,
+      tone = tagsOfType("tone").headOption,
+      blog = tagsOfType("blog").headOption
+    )
   }
 }


### PR DESCRIPTION
This is a code optimisation.

Previously, the way to tell when to stop loading pages was [when the last page failed to load](https://github.com/guardian/manage-help-content-publisher/blob/main/legacy-content-import/src/main/scala/legacycontentimport/Article.scala#L31).

Now we find out [how many pages there are in all](https://github.com/guardian/manage-help-content-publisher/compare/kc-no-exception?expand=1#diff-d9537d7865d1f49029ebaf513fa80beefc048f2958d0305f8106a956eaf7a601R37) when we load the first page and then [fold over the range of page indices, using the first page of results as the base of the fold](https://github.com/guardian/manage-help-content-publisher/compare/kc-no-exception?expand=1#diff-d9537d7865d1f49029ebaf513fa80beefc048f2958d0305f8106a956eaf7a601R29).
