### PR TITLE
Import Capi articles into Salesforce

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # Manage Help Content Publisher
+
+This repo holds code to publish Help Centre content to [MMA](https://manage.theguardian.com/help-centre).
+The content is stored in Salesforce Knowledge.
+
+It also holds [a sub-project to import articles into Salesforce from Capi](legacy-content-import).  

--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,7 @@ lazy val legacyContentImport = (project in file("legacy-content-import"))
     name := "legacy-content-import",
     libraryDependencies ++= Seq(
       http,
-      upickle
+      ujson,
+      zip
     )
   )

--- a/legacy-content-import/README.md
+++ b/legacy-content-import/README.md
@@ -1,0 +1,40 @@
+# Importing Salesforce Knowledge Articles
+
+## Program
+Use the [Importer](src/main/scala/legacycontentimport/importer/Main.scala) program to generate a zip file for Article Import in Salesforce.  
+The program takes a list of Capi IDs that are to be imported into Salesforce.  
+The generated zip file is described below, along with instructions for how to manually build the file.  
+
+## Import process
+
+The import of a batch of new articles uses a zip file with this structure:
+
+- field-values (csv)
+- import-config (properties)
+- body
+  - article-body 1 (HTML)
+  - article-body 2 (HTML)
+  - ...
+  - article-body N (HTML)
+
+This can be built and submitted with the following steps.
+
+1. Create a CSV file for article import.  
+    It should have a title row with fields for `Title` and custom fields.  The names of custom fields are case sensitive.  
+    Each row below the title row should be for a single article.
+1. Create an HTML file for content of each rich text field.  
+    In custom field in CSV, put the relative path to the HTML file.  
+    Any unencoded HTML entity in the input will be stored as an encoded entity in Knowledge. 
+1. Create a properties file.
+1. Add the CSV file, the properties file and the HTML files into a zip file.
+1. Import the zip file into Salesforce.  
+    Navigate: Setup > Import Articles  
+    This page also shows the steps to take for an import.
+
+NB:
+* Importing an article with the same URL field value as an article that has already been imported will fail.
+  This import method is only for creating new articles.  It can't be used for updates.
+
+References
+
+* https://help.salesforce.com/articleView?id=sf.knowledge_article_importer.htm

--- a/legacy-content-import/src/main/resources/import.properties
+++ b/legacy-content-import/src/main/resources/import.properties
@@ -1,0 +1,5 @@
+DateFormat=yyyy-MM-dd
+DateTimeFormat=yyyy-MM-dd HH:mm:ss
+CSVEncoding=UTF-8
+CSVSeparator=,
+RTAEncoding=UTF-8

--- a/legacy-content-import/src/main/scala/legacycontentimport/audit/Article.scala
+++ b/legacy-content-import/src/main/scala/legacycontentimport/audit/Article.scala
@@ -1,4 +1,4 @@
-package legacycontentimport
+package legacycontentimport.audit
 
 import scalaj.http.Http
 

--- a/legacy-content-import/src/main/scala/legacycontentimport/audit/Main.scala
+++ b/legacy-content-import/src/main/scala/legacycontentimport/audit/Main.scala
@@ -1,4 +1,4 @@
-package legacycontentimport
+package legacycontentimport.audit
 
 object Main extends App {
 

--- a/legacy-content-import/src/main/scala/legacycontentimport/importer/Article.scala
+++ b/legacy-content-import/src/main/scala/legacycontentimport/importer/Article.scala
@@ -1,0 +1,32 @@
+package legacycontentimport.importer
+
+import scalaj.http.Http
+
+case class Article(
+    resourceName: String,
+    title: String,
+    body: String
+)
+
+object Article {
+
+  def fromCapiPath(capiDomain: String, capiKey: String)(path: String): Article = {
+
+    def resourceNameFromPath(path: String) = path.substring(path.lastIndexOf('/') + 1)
+
+    val responseBody =
+      Http(s"https://$capiDomain/$path")
+        .param("api-key", capiKey)
+        .param("show-fields", "body")
+        .asString
+        .body
+
+    val content = ujson.read(responseBody)("response")("content")
+
+    Article(
+      resourceName = resourceNameFromPath(content("id").str),
+      title = content("webTitle").str,
+      body = content("fields")("body").str
+    )
+  }
+}

--- a/legacy-content-import/src/main/scala/legacycontentimport/importer/ImportStructure.scala
+++ b/legacy-content-import/src/main/scala/legacycontentimport/importer/ImportStructure.scala
@@ -1,0 +1,34 @@
+package legacycontentimport.importer
+
+import org.zeroturnaround.zip.ByteSource
+
+import java.nio.charset.StandardCharsets.UTF_8
+
+/** <p>The Salesforce Knowledge import requires a CSV file with a row per article.<br />
+  * Rich-text fields are treated specially: the CSV field holds a path relative to the CSV file where a HTML file
+  * can be found containing the content of the field.</p>
+  * <p>The CSV file and all the rich-text files have to be packed together into a zip file.</p>
+  *
+  * @param csv Multi-line string holding the content of the CSV file
+  * @param articleBodies Seq of HTML contents of article body fields
+  */
+case class ImportStructure(csv: String, articleBodies: Seq[ByteSource])
+
+object ImportStructure {
+
+  def addPath(loadArticle: String => Article)(importStructure: ImportStructure, path: String): ImportStructure = {
+
+    val article = loadArticle(path)
+    val pathToBody = s"body/${article.resourceName}.html"
+    val csvRow = Seq(
+      article.resourceName,
+      article.title,
+      pathToBody
+    ).mkString("\"", "\",\"", "\"")
+
+    ImportStructure(
+      csv = s"${importStructure.csv}\n$csvRow",
+      articleBodies = importStructure.articleBodies :+ new ByteSource(pathToBody, article.body.getBytes(UTF_8))
+    )
+  }
+}

--- a/legacy-content-import/src/main/scala/legacycontentimport/importer/Main.scala
+++ b/legacy-content-import/src/main/scala/legacycontentimport/importer/Main.scala
@@ -1,0 +1,44 @@
+package legacycontentimport.importer
+
+import org.zeroturnaround.zip.{ByteSource, ZipUtil}
+
+import java.io.File
+import java.nio.charset.StandardCharsets.UTF_8
+import scala.io.Source
+
+/** Generates a Salesforce Knowledge import file.
+  *
+  * Expected commandline args:
+  * <ol>
+  * <li>Capi key</li>
+  * <li>Capi domain</li>
+  * <li>File holding line-separated Capi article paths</li>
+  * </ol>
+  */
+object Main extends App {
+
+  val capiKey = args(0)
+  val capiDomain = args(1)
+  val articlePathsFile = new File(args(2))
+
+  val article = Article.fromCapiPath(capiDomain, capiKey) _
+
+  val articlePaths = {
+    val source = Source.fromFile(articlePathsFile)
+    val paths = source.getLines.toList
+    source.close()
+    paths
+  }
+
+  val csvHeader = "UrlName,Title,Body__c"
+
+  val importStructure = articlePaths.foldLeft(ImportStructure(csvHeader, Nil))(ImportStructure.addPath(article))
+
+  private val outputZip = File.createTempFile("legacy-help-articles", ".zip")
+  private val properties = new File("legacy-content-import/src/main/resources/import.properties")
+  ZipUtil.packEntry(properties, outputZip)
+  ZipUtil.addEntry(outputZip, new ByteSource("legacy-help-articles.csv", importStructure.csv.getBytes(UTF_8)))
+  importStructure.articleBodies.foreach(ZipUtil.addEntry(outputZip, _))
+
+  println(s"Import file is at $outputZip")
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,9 +4,11 @@ object Dependencies {
   val circeVersion = "0.13.0"
 
   lazy val http = "org.scalaj" %% "scalaj-http" % "2.4.2"
+  lazy val ujson = "com.lihaoyi" %% "ujson" % "1.2.3"
   lazy val upickle = "com.lihaoyi" %% "upickle" % "1.2.3"
   lazy val circeCore = "io.circe" %% "circe-core" % circeVersion
   lazy val circeGeneric = "io.circe" %% "circe-generic" % circeVersion
   lazy val circeParser = "io.circe" %% "circe-parser" % circeVersion
   lazy val jsoup = "org.jsoup" % "jsoup" % "1.13.1"
+  lazy val zip = "org.zeroturnaround" % "zt-zip" % "1.14"
 }


### PR DESCRIPTION
This adds a script to generate a zip file for Article Import in Salesforce Knowledge.
It follows the import process described [here](https://help.salesforce.com/articleView?id=sf.knowledge_article_importer.htm).

This script has already been used to import a batch of articles into the Dev org.
