### PR TITLE
Import topics with articles

### DIFF
--- a/legacy-content-import/src/main/scala/legacycontentimport/importer/ArticleAndTopics.scala
+++ b/legacy-content-import/src/main/scala/legacycontentimport/importer/ArticleAndTopics.scala
@@ -1,0 +1,7 @@
+package legacycontentimport.importer
+
+case class ArticleAndTopics(article: Article, topics: Set[String]) {
+  val resourceName = article.resourceName
+  val title = article.title
+  val body = article.body
+}

--- a/legacy-content-import/src/main/scala/legacycontentimport/importer/ImportStructure.scala
+++ b/legacy-content-import/src/main/scala/legacycontentimport/importer/ImportStructure.scala
@@ -16,14 +16,22 @@ case class ImportStructure(csv: String, articleBodies: Seq[ByteSource])
 
 object ImportStructure {
 
-  def addPath(loadArticle: String => Article)(importStructure: ImportStructure, path: String): ImportStructure = {
+  def addPath(
+      loadArticle: String => ArticleAndTopics
+  )(importStructure: ImportStructure, path: String): ImportStructure = {
 
     val article = loadArticle(path)
     val pathToBody = s"body/${article.resourceName}.html"
+
+    /*
+     * See examples in
+     * https://help.salesforce.com/articleView?id=sf.knowledge_article_importer_02csv.htm
+     */
     val csvRow = Seq(
       article.resourceName,
       article.title,
-      pathToBody
+      pathToBody,
+      article.topics.mkString("+")
     ).mkString("\"", "\",\"", "\"")
 
     ImportStructure(


### PR DESCRIPTION
We have a script that imports legacy articles from the help section of the main site and generates a zip file from them suitable for importing into Salesforce.
With this change we are able to include topics in the import of articles.

Previously, the Salesforce import file was generated from an input file consisting of line-separated Capi paths.
Eg.
```
help/2021/feb/08/getting-started-with-your-digital-subscription
help/2021/feb/03/id-like-to-make-a-complaint-about-an-advertisement
help/2021/feb/03/what-does-signing-in-mean-for-my-data
```

But now the input file includes the new Help Centre topics for each article, like so:
```
help/2021/feb/08/getting-started-with-your-digital-subscription,The_Guardian_apps
help/2021/feb/03/id-like-to-make-a-complaint-about-an-advertisement,The_Guardian_Website
help/2021/feb/03/what-does-signing-in-mean-for-my-data,Accounts_Sign_in
```
