### PR TITLE
Add script to delete all articles

### DIFF
--- a/legacy-content-import/scripts/DeleteAllArticles.apex
+++ b/legacy-content-import/scripts/DeleteAllArticles.apex
@@ -3,6 +3,19 @@
  */
 
 
+// Delete draft articles
+
+List<Knowledge__kav> draft = [
+  SELECT KnowledgeArticleId
+  FROM Knowledge__kav
+  WHERE PublishStatus = 'Draft'
+];
+
+for (Knowledge__kav article: draft) {
+  KbManagement.PublishingService.deleteDraftArticle(article.KnowledgeArticleId);
+}
+
+
 // Cannot delete live articles so archive them instead
 
 List<Knowledge__kav> live = [
@@ -26,17 +39,4 @@ List<Knowledge__kav> archived = [
 
 for (Knowledge__kav article: archived) {
   KbManagement.PublishingService.deleteArchivedArticle(article.KnowledgeArticleId);
-}
-
-
-// Delete draft articles
-
-List<Knowledge__kav> draft = [
-  SELECT KnowledgeArticleId
-  FROM Knowledge__kav
-  WHERE PublishStatus = 'Draft'
-];
-
-for (Knowledge__kav article: draft) {
-  KbManagement.PublishingService.deleteDraftArticle(article.KnowledgeArticleId);
 }

--- a/legacy-content-import/scripts/DeleteAllArticles.apex
+++ b/legacy-content-import/scripts/DeleteAllArticles.apex
@@ -1,0 +1,42 @@
+/*
+ * Delete all Knowledge articles
+ */
+
+
+// Cannot delete live articles so archive them instead
+
+List<Knowledge__kav> live = [
+  SELECT KnowledgeArticleId
+  FROM Knowledge__kav
+  WHERE PublishStatus = 'Online'
+];
+
+for (Knowledge__kav article: live) {
+ KbManagement.PublishingService.archiveOnlineArticle(article.KnowledgeArticleId, null);
+}
+
+
+// Now delete archived articles
+
+List<Knowledge__kav> archived = [
+  SELECT KnowledgeArticleId
+  FROM Knowledge__kav
+  WHERE PublishStatus = 'Archived'
+];
+
+for (Knowledge__kav article: archived) {
+  KbManagement.PublishingService.deleteArchivedArticle(article.KnowledgeArticleId);
+}
+
+
+// Delete draft articles
+
+List<Knowledge__kav> draft = [
+  SELECT KnowledgeArticleId
+  FROM Knowledge__kav
+  WHERE PublishStatus = 'Draft'
+];
+
+for (Knowledge__kav article: draft) {
+  KbManagement.PublishingService.deleteDraftArticle(article.KnowledgeArticleId);
+}


### PR DESCRIPTION
This is to clear out all legacy articles in Salesforce before importing live content from Capi.
