### PR TITLE
Create lambda to publish an article

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import Dependencies._
 
-ThisBuild / scalaVersion := "2.13.4"
+ThisBuild / scalaVersion := "2.13.5"
 
 lazy val root = (project in file("."))
   .settings(
@@ -10,7 +10,13 @@ lazy val root = (project in file("."))
       circeCore,
       circeGeneric,
       circeParser,
-      jsoup
+      jsoup,
+      ujson,
+      upickle,
+      awsLambda,
+      awsEvents,
+      s3,
+      utest % Test
     )
   )
 
@@ -24,3 +30,13 @@ lazy val legacyContentImport = (project in file("legacy-content-import"))
       zip
     )
   )
+
+testFrameworks += new TestFramework("utest.runner.Framework")
+
+assemblyMergeStrategy in assembly := {
+  case "module-info.class"                                  => MergeStrategy.discard
+  case PathList("META-INF", "io.netty.versions.properties") => MergeStrategy.discard
+  case x =>
+    val oldStrategy = (assemblyMergeStrategy in assembly).value
+    oldStrategy(x)
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,12 +2,18 @@ import sbt._
 
 object Dependencies {
   val circeVersion = "0.13.0"
+  val upickleVersion = "1.3.0"
 
   lazy val http = "org.scalaj" %% "scalaj-http" % "2.4.2"
-  lazy val ujson = "com.lihaoyi" %% "ujson" % "1.2.3"
+  lazy val ujson = "com.lihaoyi" %% "ujson" % upickleVersion
+  lazy val upickle = "com.lihaoyi" %% "upickle" % upickleVersion
   lazy val circeCore = "io.circe" %% "circe-core" % circeVersion
   lazy val circeGeneric = "io.circe" %% "circe-generic" % circeVersion
   lazy val circeParser = "io.circe" %% "circe-parser" % circeVersion
   lazy val jsoup = "org.jsoup" % "jsoup" % "1.13.1"
   lazy val zip = "org.zeroturnaround" % "zt-zip" % "1.14"
+  lazy val utest = "com.lihaoyi" %% "utest" % "0.7.7"
+  lazy val awsLambda = "com.amazonaws" % "aws-lambda-java-core" % "1.2.1"
+  lazy val awsEvents = "com.amazonaws" % "aws-lambda-java-events" % "3.7.0"
+  lazy val s3 = "software.amazon.awssdk" % "s3" % "2.16.16"
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")

--- a/src/main/scala/managehelpcontentpublisher/Article.scala
+++ b/src/main/scala/managehelpcontentpublisher/Article.scala
@@ -1,0 +1,9 @@
+package managehelpcontentpublisher
+
+import upickle.default._
+
+case class Article(title: String, body: String, path: String, topics: Seq[Topic])
+
+object Article {
+  implicit val reader: Reader[Article] = macroR
+}

--- a/src/main/scala/managehelpcontentpublisher/Failure.scala
+++ b/src/main/scala/managehelpcontentpublisher/Failure.scala
@@ -1,0 +1,3 @@
+package managehelpcontentpublisher
+
+case class Failure(reason: String)

--- a/src/main/scala/managehelpcontentpublisher/Handler.scala
+++ b/src/main/scala/managehelpcontentpublisher/Handler.scala
@@ -75,7 +75,7 @@ object Handler {
     ujson.Obj(
       "title" -> article.title,
       "body" -> HtmlToJson(article.body),
-      "topics" -> article.topics.map(topic => ujson.Obj("path" -> topic.path, "name" -> topic.name))
+      "topics" -> article.topics.map(topic => ujson.Obj("path" -> topic.path, "title" -> topic.name))
     )
 
   private def storeInS3(s3: S3Client, bucketName: String, folder: String)(

--- a/src/main/scala/managehelpcontentpublisher/Handler.scala
+++ b/src/main/scala/managehelpcontentpublisher/Handler.scala
@@ -1,0 +1,95 @@
+package managehelpcontentpublisher
+
+import com.amazonaws.services.lambda.runtime.Context
+import com.amazonaws.services.lambda.runtime.events.{APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent}
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.regions.Region.EU_WEST_1
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+
+import scala.util.Try
+import upickle.default._
+
+object Handler {
+
+  def handleRequest(event: APIGatewayProxyRequestEvent, context: Context): APIGatewayProxyResponseEvent = {
+
+    val logger = context.getLogger
+    def logInfo(message: String): Unit = logger.log(s"INFO: $message")
+    def logError(message: String): Unit = logger.log(s"ERROR: $message")
+
+    logInfo(s"Input: ${event.getBody}")
+    val response = result(event.getBody) match {
+      case Left(e) =>
+        logError(e.reason)
+        new APIGatewayProxyResponseEvent().withStatusCode(500).withBody(e.reason)
+      case Right(obj) =>
+        logInfo(s"Generated: ${obj.render(indent = 2)}")
+        new APIGatewayProxyResponseEvent().withStatusCode(204)
+    }
+    logInfo(s"Response: ${response.toString}")
+    response
+  }
+
+  def main(args: Array[String]): Unit =
+    result(args(0)) match {
+      case Left(e)    => println(s"Failed: ${e.reason}")
+      case Right(obj) => println(s"Success!: ${obj.render(indent = 2)}")
+    }
+
+  private case class AwsConfig(region: Region, bucketName: String, articlesFolder: String, topicsFolder: String)
+  private case class Config(stage: String, awsConfig: AwsConfig)
+
+  private val config = {
+    val stage = "DEV"
+    Config(
+      stage,
+      AwsConfig(
+        region = EU_WEST_1,
+        bucketName = "manage-help-content",
+        articlesFolder = s"$stage/articles",
+        topicsFolder = s"$stage/topics"
+      )
+    )
+  }
+
+  private val storeArticleInS3 = storeInS3(
+    s3 = S3Client
+      .builder()
+      .region(config.awsConfig.region)
+      .build(),
+    bucketName = config.awsConfig.bucketName,
+    folder = config.awsConfig.articlesFolder
+  ) _
+
+  private def result(articleJsonString: String) = for {
+    article <- Try(read[Article](articleJsonString)).toEither.left.map(e =>
+      Failure(s"Failed to read article from input: ${e.getMessage}")
+    )
+    json <- Right(toJson(article))
+    _ <- storeArticleInS3(s"${article.path}.json", json)
+  } yield json
+
+  private def toJson(article: Article): ujson.Obj =
+    ujson.Obj(
+      "title" -> article.title,
+      "body" -> HtmlToJson(article.body),
+      "topics" -> article.topics.map(topic => ujson.Obj("path" -> topic.path, "name" -> topic.name))
+    )
+
+  private def storeInS3(s3: S3Client, bucketName: String, folder: String)(
+      fileName: String,
+      content: ujson.Obj
+  ): Either[Failure, Unit] =
+    Try(
+      s3.putObject(
+        PutObjectRequest
+          .builder()
+          .bucket(bucketName)
+          .key(s"$folder/$fileName")
+          .build(),
+        RequestBody.fromString(content.render())
+      )
+    ).toEither.left.map(e => Failure(s"Failed to store '$fileName' in S3: ${e.getMessage}")).map(_ => ())
+}

--- a/src/main/scala/managehelpcontentpublisher/HtmlToJson.scala
+++ b/src/main/scala/managehelpcontentpublisher/HtmlToJson.scala
@@ -2,29 +2,84 @@ package managehelpcontentpublisher
 
 import org.jsoup._
 import org.jsoup.nodes._
+import org.jsoup.safety.Whitelist
 
 import scala.jdk.CollectionConverters._
 
 object HtmlToJson {
 
   def apply(html: String): ujson.Value = {
-    val body = Jsoup.parse(html.trim).body
-    htmlToJson(body).obj("content")
+    val body = Jsoup.parseBodyFragment(html.trim).body
+    htmlToJson(refined(body)).obj("content")
+  }
+
+  private def refined(body: Element): Element = {
+
+    def blankTextNodesRemoved(e: Element): Element = {
+
+      def go(acc: Set[TextNode])(curr: Node): Set[TextNode] =
+        curr match {
+          case t: TextNode if t.isBlank => acc + t
+          case _: TextNode              => acc
+          case e: Element =>
+            e.childNodes.asScala.flatMap(go(acc)).toSet
+        }
+
+      val cleaned = e.clone()
+      val blankText = go(Set.empty)(cleaned)
+      blankText.foreach(_.remove())
+      cleaned
+    }
+
+    def unsupportedAttributesRemoved(e: Element): Element =
+      Jsoup.parseBodyFragment(Jsoup.clean(e.outerHtml, Whitelist.relaxed())).body
+
+    def lineBreaksRemoved(e: Element): Element = {
+
+      def remove(br: Element): Unit = {
+        br.previousSibling.wrap("<p>")
+        br.nextSibling.wrap("<p>")
+        br.remove()
+      }
+
+      val cleaned = e.clone()
+      val lineBreaks = cleaned.select("br").asScala.toSet
+      for (break <- lineBreaks) remove(break)
+      cleaned
+    }
+
+    def emptyParagraphsRemoved(e: Element): Element = {
+      val cleaned = e.clone()
+      val emptyParas = cleaned.select("p:empty").asScala.toSet
+      for (para <- emptyParas) para.remove()
+      cleaned
+    }
+
+    (
+      lineBreaksRemoved _ andThen
+        unsupportedAttributesRemoved andThen
+        blankTextNodesRemoved andThen
+        emptyParagraphsRemoved
+    )(body)
   }
 
   private def htmlToJson(n: Node): ujson.Value =
     n match {
-      case t: TextNode => ujson.Obj("text" -> t.text)
+      case t: TextNode => ujson.Obj("element" -> "text", "content" -> t.text)
       case e: Element  => toJson(e)
     }
 
-  private def toJson(e: Element) = {
+  private def toJson(e: Element): ujson.Obj = {
     val obj = ujson.Obj(
-      "element" -> e.tagName,
+      "element" -> transformed(e.tagName),
       "content" -> e.childNodes.asScala.toList.map(htmlToJson)
     )
     e.attributes.asList.asScala.foldLeft(obj)((acc, attribute) =>
       acc.copy(acc.value ++ Map(attribute.getKey -> attribute.getValue))
     )
   }
+
+  private val elementTransformations = Map("strong" -> "b", "em" -> "i")
+
+  private def transformed(elementName: String): String = elementTransformations.getOrElse(elementName, elementName)
 }

--- a/src/main/scala/managehelpcontentpublisher/HtmlToJson.scala
+++ b/src/main/scala/managehelpcontentpublisher/HtmlToJson.scala
@@ -1,0 +1,30 @@
+package managehelpcontentpublisher
+
+import org.jsoup._
+import org.jsoup.nodes._
+
+import scala.jdk.CollectionConverters._
+
+object HtmlToJson {
+
+  def apply(html: String): ujson.Value = {
+    val body = Jsoup.parse(html.trim).body
+    htmlToJson(body).obj("content")
+  }
+
+  private def htmlToJson(n: Node): ujson.Value =
+    n match {
+      case t: TextNode => ujson.Obj("text" -> t.text)
+      case e: Element  => toJson(e)
+    }
+
+  private def toJson(e: Element) = {
+    val obj = ujson.Obj(
+      "element" -> e.tagName,
+      "content" -> e.childNodes.asScala.toList.map(htmlToJson)
+    )
+    e.attributes.asList.asScala.foldLeft(obj)((acc, attribute) =>
+      acc.copy(acc.value ++ Map(attribute.getKey -> attribute.getValue))
+    )
+  }
+}

--- a/src/main/scala/managehelpcontentpublisher/Topic.scala
+++ b/src/main/scala/managehelpcontentpublisher/Topic.scala
@@ -1,0 +1,9 @@
+package managehelpcontentpublisher
+
+import upickle.default._
+
+case class Topic(path: String, name: String)
+
+object Topic {
+  implicit val reader: Reader[Topic] = macroR
+}

--- a/src/test/scala/managehelpcontentpublisher/HtmlToJsonTestSuite.scala
+++ b/src/test/scala/managehelpcontentpublisher/HtmlToJsonTestSuite.scala
@@ -1,0 +1,79 @@
+package managehelpcontentpublisher
+
+import utest._
+
+object HtmlToJsonTestSuite extends TestSuite {
+  val tests: Tests = Tests {
+    test("Works with an article with multiple elements and inline links") {
+      val input = """<p><strong>Digital subscribers</strong> can log in on up to 10 devices.</p>
+                |
+                |<p><strong>Apple/Google subscribers</strong> are only able to log in on the device they subscribed with. If you&rsquo;d like to use your subscription on more than one device we&rsquo;d recommend exploring a <a href="https://support.theguardian.com/uk/subscribe/digital" target="_blank">digital subscription</a>, which gives you premium tier access on up to 10 devices, along with access to the Guardian and Observer Daily Edition.</p>
+                |
+                |<p>If you have an account that is not associated with a digital or Apple/Google subscription, then you can log in on as many devices as you wish.</p>
+                |""".stripMargin
+      val expected =
+        """[
+          |  {
+          |    "element": "p",
+          |    "content": [
+          |      {
+          |        "element": "strong",
+          |        "content": [
+          |          {
+          |            "text": "Digital subscribers"
+          |          }
+          |        ]
+          |      },
+          |      {
+          |        "text": " can log in on up to 10 devices."
+          |      }
+          |    ]
+          |  },
+          |  {
+          |    "text": " "
+          |  },
+          |  {
+          |    "element": "p",
+          |    "content": [
+          |      {
+          |        "element": "strong",
+          |        "content": [
+          |          {
+          |            "text": "Apple/Google subscribers"
+          |          }
+          |        ]
+          |      },
+          |      {
+          |        "text": " are only able to log in on the device they subscribed with. If you’d like to use your subscription on more than one device we’d recommend exploring a "
+          |      },
+          |      {
+          |        "element": "a",
+          |        "content": [
+          |          {
+          |            "text": "digital subscription"
+          |          }
+          |        ],
+          |        "href": "https://support.theguardian.com/uk/subscribe/digital",
+          |        "target": "_blank"
+          |      },
+          |      {
+          |        "text": ", which gives you premium tier access on up to 10 devices, along with access to the Guardian and Observer Daily Edition."
+          |      }
+          |    ]
+          |  },
+          |  {
+          |    "text": " "
+          |  },
+          |  {
+          |    "element": "p",
+          |    "content": [
+          |      {
+          |        "text": "If you have an account that is not associated with a digital or Apple/Google subscription, then you can log in on as many devices as you wish."
+          |      }
+          |    ]
+          |  }
+          |]""".stripMargin
+      HtmlToJson(input).render(indent = 2) ==> expected
+    }
+  }
+}

--- a/src/test/scala/managehelpcontentpublisher/HtmlToJsonTestSuite.scala
+++ b/src/test/scala/managehelpcontentpublisher/HtmlToJsonTestSuite.scala
@@ -2,9 +2,369 @@ package managehelpcontentpublisher
 
 import utest._
 
+/** See [[https://github.com/guardian/salesforce/blob/master/force-app/main/default/classes/ArticleBodyValidation.cls#L5-L20 list of HTML elements we support in Salesforce]].
+  */
 object HtmlToJsonTestSuite extends TestSuite {
   val tests: Tests = Tests {
-    test("Works with an article with multiple elements and inline links") {
+
+    test("Element h2") {
+      HtmlToJson("<h2>some subheading</h2>").render(indent = 2) ==> """[
+                    |  {
+                    |    "element": "h2",
+                    |    "content": [
+                    |      {
+                    |        "element": "text",
+                    |        "content": "some subheading"
+                    |      }
+                    |    ]
+                    |  }
+                    |]""".stripMargin
+    }
+
+    test("Element p") {
+      HtmlToJson("<p>This is a sentence.</p>").render(indent = 2) ==> """[
+                    |  {
+                    |    "element": "p",
+                    |    "content": [
+                    |      {
+                    |        "element": "text",
+                    |        "content": "This is a sentence."
+                    |      }
+                    |    ]
+                    |  }
+                    |]""".stripMargin
+    }
+
+    test("Element ol") {
+      HtmlToJson("""<ol>
+                   |  <li>First</li>
+                   |  <li>Second</li>
+                   |  <li>Third</li>
+                   |</ol>
+                   |""".stripMargin)
+        .render(indent = 2) ==> """[
+                                        |  {
+                                        |    "element": "ol",
+                                        |    "content": [
+                                        |      {
+                                        |        "element": "li",
+                                        |        "content": [
+                                        |          {
+                                        |            "element": "text",
+                                        |            "content": "First"
+                                        |          }
+                                        |        ]
+                                        |      },
+                                        |      {
+                                        |        "element": "li",
+                                        |        "content": [
+                                        |          {
+                                        |            "element": "text",
+                                        |            "content": "Second"
+                                        |          }
+                                        |        ]
+                                        |      },
+                                        |      {
+                                        |        "element": "li",
+                                        |        "content": [
+                                        |          {
+                                        |            "element": "text",
+                                        |            "content": "Third"
+                                        |          }
+                                        |        ]
+                                        |      }
+                                        |    ]
+                                        |  }
+                                        |]""".stripMargin
+    }
+
+    test("Element ul") {
+      HtmlToJson("""<ul>
+                   |  <li>Something</li>
+                   |  <li>Another thing</li>
+                   |  <li>Something else</li>
+                   |</ul>
+                   |""".stripMargin)
+        .render(indent = 2) ==> """[
+                                        |  {
+                                        |    "element": "ul",
+                                        |    "content": [
+                                        |      {
+                                        |        "element": "li",
+                                        |        "content": [
+                                        |          {
+                                        |            "element": "text",
+                                        |            "content": "Something"
+                                        |          }
+                                        |        ]
+                                        |      },
+                                        |      {
+                                        |        "element": "li",
+                                        |        "content": [
+                                        |          {
+                                        |            "element": "text",
+                                        |            "content": "Another thing"
+                                        |          }
+                                        |        ]
+                                        |      },
+                                        |      {
+                                        |        "element": "li",
+                                        |        "content": [
+                                        |          {
+                                        |            "element": "text",
+                                        |            "content": "Something else"
+                                        |          }
+                                        |        ]
+                                        |      }
+                                        |    ]
+                                        |  }
+                                        |]""".stripMargin
+    }
+
+    test("Element br") {
+      test("inside middle of paragraph") {
+        HtmlToJson("<p>Breaking the paragraph here.<br>And starting again.</p>")
+          .render(indent = 2) ==> """[
+                                            |  {
+                                            |    "element": "p",
+                                            |    "content": [
+                                            |      {
+                                            |        "element": "text",
+                                            |        "content": "Breaking the paragraph here."
+                                            |      }
+                                            |    ]
+                                            |  },
+                                            |  {
+                                            |    "element": "p",
+                                            |    "content": [
+                                            |      {
+                                            |        "element": "text",
+                                            |        "content": "And starting again."
+                                            |      }
+                                            |    ]
+                                            |  }
+                                            |]""".stripMargin
+      }
+
+      test("after non-para text") {
+        HtmlToJson("Breaking the paragraph here.<br><p>And starting again.</p>")
+          .render(indent = 2) ==> """[
+                                            |  {
+                                            |    "element": "p",
+                                            |    "content": [
+                                            |      {
+                                            |        "element": "text",
+                                            |        "content": "Breaking the paragraph here."
+                                            |      }
+                                            |    ]
+                                            |  },
+                                            |  {
+                                            |    "element": "p",
+                                            |    "content": [
+                                            |      {
+                                            |        "element": "text",
+                                            |        "content": "And starting again."
+                                            |      }
+                                            |    ]
+                                            |  }
+                                            |]""".stripMargin
+      }
+
+      test("before non-para text") {
+        HtmlToJson("<p>Breaking the paragraph here.</p><br>And starting again.")
+          .render(indent = 2) ==> """[
+                                            |  {
+                                            |    "element": "p",
+                                            |    "content": [
+                                            |      {
+                                            |        "element": "text",
+                                            |        "content": "Breaking the paragraph here."
+                                            |      }
+                                            |    ]
+                                            |  },
+                                            |  {
+                                            |    "element": "p",
+                                            |    "content": [
+                                            |      {
+                                            |        "element": "text",
+                                            |        "content": "And starting again."
+                                            |      }
+                                            |    ]
+                                            |  }
+                                            |]""".stripMargin
+      }
+
+      test("between non-para text") {
+        HtmlToJson("Breaking the paragraph here.<br>And starting again.")
+          .render(indent = 2) ==> """[
+                                            |  {
+                                            |    "element": "p",
+                                            |    "content": [
+                                            |      {
+                                            |        "element": "text",
+                                            |        "content": "Breaking the paragraph here."
+                                            |      }
+                                            |    ]
+                                            |  },
+                                            |  {
+                                            |    "element": "p",
+                                            |    "content": [
+                                            |      {
+                                            |        "element": "text",
+                                            |        "content": "And starting again."
+                                            |      }
+                                            |    ]
+                                            |  }
+                                            |]""".stripMargin
+      }
+    }
+
+    test("Element a") {
+      HtmlToJson(
+        """<a href="https://support.theguardian.com/uk/subscribe/digital" target="_blank">digital subscription</a>"""
+      )
+        .render(indent = 2) ==> """[
+                                        |  {
+                                        |    "element": "a",
+                                        |    "content": [
+                                        |      {
+                                        |        "element": "text",
+                                        |        "content": "digital subscription"
+                                        |      }
+                                        |    ],
+                                        |    "href": "https://support.theguardian.com/uk/subscribe/digital"
+                                        |  }
+                                        |]""".stripMargin
+    }
+
+    test("Element b") {
+      HtmlToJson("<p>This is <b>very</b> important</p>")
+        .render(indent = 2) ==> """[
+                                        |  {
+                                        |    "element": "p",
+                                        |    "content": [
+                                        |      {
+                                        |        "element": "text",
+                                        |        "content": "This is "
+                                        |      },
+                                        |      {
+                                        |        "element": "b",
+                                        |        "content": [
+                                        |          {
+                                        |            "element": "text",
+                                        |            "content": "very"
+                                        |          }
+                                        |        ]
+                                        |      },
+                                        |      {
+                                        |        "element": "text",
+                                        |        "content": " important"
+                                        |      }
+                                        |    ]
+                                        |  }
+                                        |]""".stripMargin
+    }
+
+    test("Element strong") {
+      HtmlToJson("<p>This is <strong>very</strong> important</p>")
+        .render(indent = 2) ==> """[
+                                        |  {
+                                        |    "element": "p",
+                                        |    "content": [
+                                        |      {
+                                        |        "element": "text",
+                                        |        "content": "This is "
+                                        |      },
+                                        |      {
+                                        |        "element": "b",
+                                        |        "content": [
+                                        |          {
+                                        |            "element": "text",
+                                        |            "content": "very"
+                                        |          }
+                                        |        ]
+                                        |      },
+                                        |      {
+                                        |        "element": "text",
+                                        |        "content": " important"
+                                        |      }
+                                        |    ]
+                                        |  }
+                                        |]""".stripMargin
+    }
+
+    test("Element i") {
+      HtmlToJson("<p>Something <i>amazing</i> happened</p>")
+        .render(indent = 2) ==> """[
+                                        |  {
+                                        |    "element": "p",
+                                        |    "content": [
+                                        |      {
+                                        |        "element": "text",
+                                        |        "content": "Something "
+                                        |      },
+                                        |      {
+                                        |        "element": "i",
+                                        |        "content": [
+                                        |          {
+                                        |            "element": "text",
+                                        |            "content": "amazing"
+                                        |          }
+                                        |        ]
+                                        |      },
+                                        |      {
+                                        |        "element": "text",
+                                        |        "content": " happened"
+                                        |      }
+                                        |    ]
+                                        |  }
+                                        |]""".stripMargin
+    }
+
+    test("Element em") {
+      HtmlToJson("<p>Something <em>amazing</em> happened</p>")
+        .render(indent = 2) ==> """[
+                                        |  {
+                                        |    "element": "p",
+                                        |    "content": [
+                                        |      {
+                                        |        "element": "text",
+                                        |        "content": "Something "
+                                        |      },
+                                        |      {
+                                        |        "element": "i",
+                                        |        "content": [
+                                        |          {
+                                        |            "element": "text",
+                                        |            "content": "amazing"
+                                        |          }
+                                        |        ]
+                                        |      },
+                                        |      {
+                                        |        "element": "text",
+                                        |        "content": " happened"
+                                        |      }
+                                        |    ]
+                                        |  }
+                                        |]""".stripMargin
+    }
+
+    test("A heading with styling") {
+      HtmlToJson("""<h2 style="text-align: center;">some text</h2>""")
+        .render(indent = 2) ==> """[
+                                        |  {
+                                        |    "element": "h2",
+                                        |    "content": [
+                                        |      {
+                                        |        "element": "text",
+                                        |        "content": "some text"
+                                        |      }
+                                        |    ]
+                                        |  }
+                                        |]""".stripMargin
+    }
+
+    test("An article with multiple elements and inline links") {
       val input = """<p><strong>Digital subscribers</strong> can log in on up to 10 devices.</p>
                 |
                 |<p><strong>Apple/Google subscribers</strong> are only able to log in on the device they subscribed with. If you&rsquo;d like to use your subscription on more than one device we&rsquo;d recommend exploring a <a href="https://support.theguardian.com/uk/subscribe/digital" target="_blank">digital subscription</a>, which gives you premium tier access on up to 10 devices, along with access to the Guardian and Observer Daily Edition.</p>
@@ -17,58 +377,58 @@ object HtmlToJsonTestSuite extends TestSuite {
           |    "element": "p",
           |    "content": [
           |      {
-          |        "element": "strong",
+          |        "element": "b",
           |        "content": [
           |          {
-          |            "text": "Digital subscribers"
+          |            "element": "text",
+          |            "content": "Digital subscribers"
           |          }
           |        ]
           |      },
           |      {
-          |        "text": " can log in on up to 10 devices."
+          |        "element": "text",
+          |        "content": " can log in on up to 10 devices."
           |      }
           |    ]
-          |  },
-          |  {
-          |    "text": " "
           |  },
           |  {
           |    "element": "p",
           |    "content": [
           |      {
-          |        "element": "strong",
+          |        "element": "b",
           |        "content": [
           |          {
-          |            "text": "Apple/Google subscribers"
+          |            "element": "text",
+          |            "content": "Apple/Google subscribers"
           |          }
           |        ]
           |      },
           |      {
-          |        "text": " are only able to log in on the device they subscribed with. If you’d like to use your subscription on more than one device we’d recommend exploring a "
+          |        "element": "text",
+          |        "content": " are only able to log in on the device they subscribed with. If you’d like to use your subscription on more than one device we’d recommend exploring a "
           |      },
           |      {
           |        "element": "a",
           |        "content": [
           |          {
-          |            "text": "digital subscription"
+          |            "element": "text",
+          |            "content": "digital subscription"
           |          }
           |        ],
-          |        "href": "https://support.theguardian.com/uk/subscribe/digital",
-          |        "target": "_blank"
+          |        "href": "https://support.theguardian.com/uk/subscribe/digital"
           |      },
           |      {
-          |        "text": ", which gives you premium tier access on up to 10 devices, along with access to the Guardian and Observer Daily Edition."
+          |        "element": "text",
+          |        "content": ", which gives you premium tier access on up to 10 devices, along with access to the Guardian and Observer Daily Edition."
           |      }
           |    ]
-          |  },
-          |  {
-          |    "text": " "
           |  },
           |  {
           |    "element": "p",
           |    "content": [
           |      {
-          |        "text": "If you have an account that is not associated with a digital or Apple/Google subscription, then you can log in on as many devices as you wish."
+          |        "element": "text",
+          |        "content": "If you have an account that is not associated with a digital or Apple/Google subscription, then you can log in on as many devices as you wish."
           |      }
           |    ]
           |  }


### PR DESCRIPTION
This gives a handler that can be run from a [lambda](https://github.com/guardian/manage-help-content-publisher/compare/kc-lambda?expand=1#diff-505c88cfb00274e5b086ed8e0935cef7440b8e4931dd7ad922c2724ba2adead8R16) or [standalone](https://github.com/guardian/manage-help-content-publisher/compare/kc-lambda?expand=1#diff-505c88cfb00274e5b086ed8e0935cef7440b8e4931dd7ad922c2724ba2adead8R35).
It:
1. [takes an article from an API gateway input](https://github.com/guardian/manage-help-content-publisher/compare/kc-lambda?expand=1#diff-505c88cfb00274e5b086ed8e0935cef7440b8e4931dd7ad922c2724ba2adead8R67-R69),
1. [converts the article to an agreed Json format](https://github.com/guardian/manage-help-content-publisher/compare/kc-lambda?expand=1#diff-505c88cfb00274e5b086ed8e0935cef7440b8e4931dd7ad922c2724ba2adead8R70),
1. [writes the resulting object to an S3 bucket](https://github.com/guardian/manage-help-content-publisher/compare/kc-lambda?expand=1#diff-505c88cfb00274e5b086ed8e0935cef7440b8e4931dd7ad922c2724ba2adead8R71).

I've tested it in AWS.

The cloudformation and deployment config are still to be done.
