### PR TITLE
Run Snyk as a GitHub Action

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,0 +1,31 @@
+# This action runs every day at 6 AM and on every push
+# If the branch it's running on is main then it will run snyk monitor (reports vulnerabilities to snyk.io)
+# Otherwise it will run snyk test
+name: Snyk
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  push:
+  workflow_dispatch:
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    env:
+      SNYK_COMMAND: test
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v2
+
+      - name: Set command to monitor
+        if: github.ref == 'refs/heads/main'
+        run: echo "SNYK_COMMAND=monitor" >> $GITHUB_ENV
+
+      - name: Run Snyk to check for vulnerabilities
+        uses: snyk/actions/scala@0.3.0
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --org=the-guardian-cuu --project-name=${{ github.repository }}
+          command: ${{ env.SNYK_COMMAND }}


### PR DESCRIPTION
## What does this change?
This PR configures a GitHub Action to run Snyk. This action runs every day at 6 AM and on every push. If the branch it's running on is main then it will run `snyk monitor` (reports vulnerabilities to snyk.io), otherwise it will run `snyk test`.

## How to test
Go to GitHub Action tab to see the result of the Actions run.