### PR TITLE
Modify expected input for publishing lambda to agree with request from Salesforce

### DIFF
--- a/src/main/scala/managehelpcontentpublisher/Article.scala
+++ b/src/main/scala/managehelpcontentpublisher/Article.scala
@@ -1,9 +1,13 @@
 package managehelpcontentpublisher
 
-import upickle.default._
-
 case class Article(title: String, body: String, path: String, topics: Seq[Topic])
 
 object Article {
-  implicit val reader: Reader[Article] = macroR
+
+  def fromInput(input: InputArticle): Article = Article(
+    title = input.title,
+    body = input.body,
+    path = input.urlName,
+    topics = input.dataCategories.map(Topic.fromSalesforceDataCategory)
+  )
 }

--- a/src/main/scala/managehelpcontentpublisher/HtmlToJson.scala
+++ b/src/main/scala/managehelpcontentpublisher/HtmlToJson.scala
@@ -37,8 +37,8 @@ object HtmlToJson {
     def lineBreaksRemoved(e: Element): Element = {
 
       def remove(br: Element): Unit = {
-        br.previousSibling.wrap("<p>")
-        br.nextSibling.wrap("<p>")
+        Option(br.previousSibling).foreach(_.wrap("<p>"))
+        Option(br.nextSibling).foreach(_.wrap("<p>"))
         br.remove()
       }
 

--- a/src/main/scala/managehelpcontentpublisher/InputModel.scala
+++ b/src/main/scala/managehelpcontentpublisher/InputModel.scala
@@ -8,18 +8,25 @@ object InputModel {
   implicit val reader: Reader[InputModel] = macroR
 }
 
+case class InputArticle(
+    title: String,
+    body: String,
+    urlName: String,
+    dataCategories: Seq[ArticleDataCategory]
+)
+
+object InputArticle {
+  implicit val reader: Reader[InputArticle] = macroR
+}
+
 case class DataCategory(name: String)
 
 object DataCategory {
   implicit val reader: Reader[DataCategory] = macroR
 }
-case class InputArticle(
-    title: String,
-    body: String,
-    urlName: String,
-    dataCategories: Seq[String]
-)
 
-object InputArticle {
-  implicit val reader: Reader[InputArticle] = macroR
+case class ArticleDataCategory(name: String, label: String)
+
+object ArticleDataCategory {
+  implicit val reader: Reader[ArticleDataCategory] = macroR
 }

--- a/src/main/scala/managehelpcontentpublisher/InputModel.scala
+++ b/src/main/scala/managehelpcontentpublisher/InputModel.scala
@@ -1,0 +1,25 @@
+package managehelpcontentpublisher
+
+import upickle.default._
+
+case class InputModel(article: InputArticle, dataCategories: Seq[DataCategory])
+
+object InputModel {
+  implicit val reader: Reader[InputModel] = macroR
+}
+
+case class DataCategory(name: String)
+
+object DataCategory {
+  implicit val reader: Reader[DataCategory] = macroR
+}
+case class InputArticle(
+    title: String,
+    body: String,
+    urlName: String,
+    dataCategories: Seq[String]
+)
+
+object InputArticle {
+  implicit val reader: Reader[InputArticle] = macroR
+}

--- a/src/main/scala/managehelpcontentpublisher/Topic.scala
+++ b/src/main/scala/managehelpcontentpublisher/Topic.scala
@@ -4,8 +4,8 @@ case class Topic(path: String, name: String)
 
 object Topic {
 
-  def fromSalesforceDataCategory(cat: String): Topic = Topic(
-    path = cat.stripSuffix("__c"),
-    name = "TODO" // TODO: fill in when request body complete
+  def fromSalesforceDataCategory(cat: ArticleDataCategory): Topic = Topic(
+    path = cat.name.stripSuffix("__c"),
+    name = cat.label
   )
 }

--- a/src/main/scala/managehelpcontentpublisher/Topic.scala
+++ b/src/main/scala/managehelpcontentpublisher/Topic.scala
@@ -1,9 +1,11 @@
 package managehelpcontentpublisher
 
-import upickle.default._
-
 case class Topic(path: String, name: String)
 
 object Topic {
-  implicit val reader: Reader[Topic] = macroR
+
+  def fromSalesforceDataCategory(cat: String): Topic = Topic(
+    path = cat.stripSuffix("__c"),
+    name = "TODO" // TODO: fill in when request body complete
+  )
 }

--- a/src/test/scala/managehelpcontentpublisher/HtmlToJsonTestSuite.scala
+++ b/src/test/scala/managehelpcontentpublisher/HtmlToJsonTestSuite.scala
@@ -217,6 +217,20 @@ object HtmlToJsonTestSuite extends TestSuite {
                                             |  }
                                             |]""".stripMargin
       }
+      test("immediately after opening p tag") {
+        HtmlToJson("<p><br>Please note that will need to give at least 3 days notice.</p>")
+          .render(indent = 2) ==> """[
+                                            |  {
+                                            |    "element": "p",
+                                            |    "content": [
+                                            |      {
+                                            |        "element": "text",
+                                            |        "content": "Please note that will need to give at least 3 days notice."
+                                            |      }
+                                            |    ]
+                                            |  }
+                                            |]""".stripMargin
+      }
     }
 
     test("Element a") {


### PR DESCRIPTION
We've agreed on an [input model](https://github.com/guardian/manage-help-content-publisher/blob/f7effaf8f6653f3826a945066d60885200c450fd/src/main/scala/managehelpcontentpublisher/InputModel.scala) that gives us all the data we need to publish articles and topics but is not too difficult to generate from Salesforce data.
