### PR TITLE
Include SLF4J No-op runtime implementation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,8 +42,9 @@ lazy val legacyContentImport = (project in file("legacy-content-import"))
 testFrameworks += new TestFramework("utest.runner.Framework")
 
 assemblyMergeStrategy in assembly := {
-  case "module-info.class"                                  => MergeStrategy.discard
-  case PathList("META-INF", "io.netty.versions.properties") => MergeStrategy.discard
+  case "module-info.class"                                      => MergeStrategy.discard
+  case PathList("META-INF", "versions", _, "module-info.class") => MergeStrategy.discard
+  case PathList("META-INF", "io.netty.versions.properties")     => MergeStrategy.discard
   case x =>
     val oldStrategy = (assemblyMergeStrategy in assembly).value
     oldStrategy(x)

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val root = (project in file("."))
     riffRaffPackageType := assembly.value,
     riffRaffUploadArtifactBucket := Option("riffraff-artifact"),
     riffRaffUploadManifestBucket := Option("riffraff-builds"),
-    riffRaffManifestProjectName := "manage-help-content-publisher",
+    riffRaffManifestProjectName := s"${name.value}",
     riffRaffArtifactResources += (file("cfn.yaml"), "cfn/cfn.yaml"),
     libraryDependencies ++= Seq(
       http,
@@ -23,6 +23,7 @@ lazy val root = (project in file("."))
       awsLambda,
       awsEvents,
       s3,
+      slf4jNop % Runtime,
       utest % Test
     )
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,4 +16,5 @@ object Dependencies {
   lazy val awsLambda = "com.amazonaws" % "aws-lambda-java-core" % "1.2.1"
   lazy val awsEvents = "com.amazonaws" % "aws-lambda-java-events" % "3.7.0"
   lazy val s3 = "software.amazon.awssdk" % "s3" % "2.16.16"
+  lazy val slf4jNop = "org.slf4j" % "slf4j-nop" % "2.0.0-alpha1"
 }


### PR DESCRIPTION
We're not actually using SLF4J but it's imported with the AWS SDK.
By using a no-op implementation at runtime we get rid of the warning:
```
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```
