### PR TITLE
Read stage from environment

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -47,6 +47,9 @@ Resources:
       CodeUri:
         Bucket: membership-dist
         Key: !Sub membership/${Stage}/${AppName}/${AppName}.jar
+      Environment:
+        Variables:
+          stage: !Ref Stage
       Timeout: 30
       MemorySize: 2048
       Events:

--- a/src/main/scala/managehelpcontentpublisher/Handler.scala
+++ b/src/main/scala/managehelpcontentpublisher/Handler.scala
@@ -7,9 +7,10 @@ import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.regions.Region.EU_WEST_1
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
-
-import scala.util.Try
 import upickle.default._
+
+import scala.sys.env
+import scala.util.Try
 
 object Handler {
 
@@ -19,6 +20,7 @@ object Handler {
     def logInfo(message: String): Unit = logger.log(s"INFO: $message")
     def logError(message: String): Unit = logger.log(s"ERROR: $message")
 
+    logInfo(s"Using config: $config")
     logInfo(s"Input: ${event.getBody}")
     val response = result(event.getBody) match {
       case Left(e) =>
@@ -32,17 +34,19 @@ object Handler {
     response
   }
 
-  def main(args: Array[String]): Unit =
+  def main(args: Array[String]): Unit = {
+    println(s"Using config: $config")
     result(args(0)) match {
       case Left(e)    => println(s"Failed: ${e.reason}")
       case Right(obj) => println(s"Success!: ${obj.render(indent = 2)}")
     }
+  }
 
   private case class AwsConfig(region: Region, bucketName: String, articlesFolder: String, topicsFolder: String)
   private case class Config(stage: String, awsConfig: AwsConfig)
 
   private val config = {
-    val stage = "DEV"
+    val stage = env.getOrElse("stage", "DEV")
     Config(
       stage,
       AwsConfig(


### PR DESCRIPTION
Previously, the stage was hardcoded to `DEV`.  This change reads it from the lambda environment instead or falls back to Dev if running outside a lambda.