### PR TITLE
Test PRs raised by Scala Steward

### DIFF
--- a/.github/workflows/handle-scala-steward-prs.yml
+++ b/.github/workflows/handle-scala-steward-prs.yml
@@ -1,0 +1,24 @@
+name: Scala Steward PR handling
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    name: Test Scala Steward PR
+    if: github.actor == 'scala-steward'
+    runs-on: ubuntu-latest
+    steps:
+    - 
+      name: Checkout repo
+      uses: actions/checkout@v2
+    - 
+      name: Set up Java
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - 
+      name: Run tests
+      run: sbt test
+      


### PR DESCRIPTION
This change gives us a Github action to test Scala Steward PRs safely outside Teamcity where they might do some damage.