### PR TITLE
Update topics when publishing an article

### DIFF
--- a/src/main/scala/managehelpcontentpublisher/Article.scala
+++ b/src/main/scala/managehelpcontentpublisher/Article.scala
@@ -1,5 +1,6 @@
 package managehelpcontentpublisher
 
+import managehelpcontentpublisher.SalesforceCleaner.cleanCustomFieldName
 import upickle.default._
 
 case class Article(title: String, body: ujson.Value, path: String, topics: Seq[ArticleTopic])
@@ -23,7 +24,7 @@ object ArticleTopic {
   implicit val writer: Writer[ArticleTopic] = macroW
 
   def fromSalesforceDataCategory(cat: ArticleDataCategory): ArticleTopic = ArticleTopic(
-    path = cat.name.stripSuffix("__c"),
+    path = cleanCustomFieldName(cat.name),
     title = cat.label
   )
 }

--- a/src/main/scala/managehelpcontentpublisher/Article.scala
+++ b/src/main/scala/managehelpcontentpublisher/Article.scala
@@ -1,13 +1,29 @@
 package managehelpcontentpublisher
 
-case class Article(title: String, body: String, path: String, topics: Seq[Topic])
+import upickle.default._
+
+case class Article(title: String, body: ujson.Value, path: String, topics: Seq[ArticleTopic])
 
 object Article {
 
+  implicit val writer: Writer[Article] = macroW
+
   def fromInput(input: InputArticle): Article = Article(
     title = input.title,
-    body = input.body,
+    body = HtmlToJson(input.body),
     path = input.urlName,
-    topics = input.dataCategories.map(Topic.fromSalesforceDataCategory)
+    topics = input.dataCategories.map(ArticleTopic.fromSalesforceDataCategory)
+  )
+}
+
+case class ArticleTopic(path: String, title: String)
+
+object ArticleTopic {
+
+  implicit val writer: Writer[ArticleTopic] = macroW
+
+  def fromSalesforceDataCategory(cat: ArticleDataCategory): ArticleTopic = ArticleTopic(
+    path = cat.name.stripSuffix("__c"),
+    title = cat.label
   )
 }

--- a/src/main/scala/managehelpcontentpublisher/Eithers.scala
+++ b/src/main/scala/managehelpcontentpublisher/Eithers.scala
@@ -1,0 +1,9 @@
+package managehelpcontentpublisher
+
+object Eithers {
+
+  def seqToEither[E, A](eithers: Seq[Either[E, A]]): Either[E, Seq[A]] =
+    eithers
+      .collectFirst { case Left(e) => Left(e) }
+      .getOrElse { Right(eithers.collect { case Right(a) => a }) }
+}

--- a/src/main/scala/managehelpcontentpublisher/Handler.scala
+++ b/src/main/scala/managehelpcontentpublisher/Handler.scala
@@ -2,15 +2,9 @@ package managehelpcontentpublisher
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.events.{APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent}
-import software.amazon.awssdk.regions.Region
-import software.amazon.awssdk.regions.Region.EU_WEST_1
-import software.amazon.awssdk.services.s3.S3Client
-import upickle.default._
 
 import java.io.File
 import scala.io.Source
-import scala.sys.env
-import scala.util.Try
 
 object Handler {
 
@@ -20,14 +14,13 @@ object Handler {
     def logInfo(message: String): Unit = logger.log(s"INFO: $message")
     def logError(message: String): Unit = logger.log(s"ERROR: $message")
 
-    logInfo(s"Using config: $config")
     logInfo(s"Input: ${event.getBody}")
-    val response = result(event.getBody) match {
+    val response = publishContents(event.getBody) match {
       case Left(e) =>
         logError(e.reason)
         new APIGatewayProxyResponseEvent().withStatusCode(500).withBody(e.reason)
-      case Right(results) =>
-        results.foreach(result => logInfo(s"Wrote to ${result.path}: ${result.content}"))
+      case Right(published) =>
+        published.foreach(item => logInfo(s"Wrote to '${item.path}': ${item.content}"))
         new APIGatewayProxyResponseEvent().withStatusCode(204)
     }
     logInfo(s"Response: ${response.toString}")
@@ -38,51 +31,14 @@ object Handler {
     val inFile = Source.fromFile(new File(args(0)))
     val input = inFile.mkString
     inFile.close()
-    result(input) match {
+    publishContents(input) match {
       case Left(e) => println(s"Failed: ${e.reason}")
-      case Right(results) =>
+      case Right(published) =>
         println(s"Success!")
-        results.foreach(result => println(s"Wrote to ${result.path}: ${result.content}"))
+        published.foreach(item => println(s"Wrote to '${item.path}': ${item.content}"))
     }
   }
 
-  private case class AwsConfig(region: Region, bucketName: String, articlesFolder: String, topicsFolder: String)
-  private case class Config(stage: String, awsConfig: AwsConfig)
-
-  private val config = {
-    val stage = env.getOrElse("stage", "DEV")
-    Config(
-      stage,
-      AwsConfig(
-        region = EU_WEST_1,
-        bucketName = "manage-help-content",
-        articlesFolder = s"$stage/articles",
-        topicsFolder = s"$stage/topics"
-      )
-    )
-  }
-
-  private case class PutResult(path: String, content: String)
-
-  private def result(jsonString: String): Either[Failure, Seq[PutResult]] = {
-
-    def readInput(jsonString: String): Either[Failure, InputModel] =
-      Try(read[InputModel](jsonString)).toEither.left.map(e => Failure(s"Failed to read input: ${e.getMessage}"))
-
-    def writeArticle(article: Article): Either[Failure, String] =
-      Try(write(article)).toEither.left.map(e => Failure(s"Failed to write article: ${e.getMessage}"))
-
-    val s3 = S3Client.builder().region(config.awsConfig.region).build()
-
-    val putArticleInS3 =
-      S3.put(s3, bucketName = config.awsConfig.bucketName, folder = config.awsConfig.articlesFolder) _
-
-    for {
-      input <- readInput(jsonString)
-      article = Article.fromInput(input.article)
-      json <- writeArticle(article)
-      path = s"${article.path}.json"
-      _ <- putArticleInS3(path, json)
-    } yield Seq(PutResult(path, json))
-  }
+  private def publishContents(jsonString: String): Either[Failure, Seq[PathAndContent]] =
+    PathAndContent.publishContents(S3.putArticle, S3.putTopic)(jsonString)
 }

--- a/src/main/scala/managehelpcontentpublisher/Handler.scala
+++ b/src/main/scala/managehelpcontentpublisher/Handler.scala
@@ -2,11 +2,9 @@ package managehelpcontentpublisher
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.events.{APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent}
-import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.regions.Region.EU_WEST_1
 import software.amazon.awssdk.services.s3.S3Client
-import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import upickle.default._
 
 import java.io.File
@@ -28,8 +26,8 @@ object Handler {
       case Left(e) =>
         logError(e.reason)
         new APIGatewayProxyResponseEvent().withStatusCode(500).withBody(e.reason)
-      case Right(obj) =>
-        logInfo(s"Generated: ${obj.render(indent = 2)}")
+      case Right(results) =>
+        results.foreach(result => logInfo(s"Wrote to ${result.path}: ${result.content}"))
         new APIGatewayProxyResponseEvent().withStatusCode(204)
     }
     logInfo(s"Response: ${response.toString}")
@@ -37,13 +35,14 @@ object Handler {
   }
 
   def main(args: Array[String]): Unit = {
-    println(s"Using config: $config")
     val inFile = Source.fromFile(new File(args(0)))
     val input = inFile.mkString
     inFile.close()
     result(input) match {
-      case Left(e)    => println(s"Failed: ${e.reason}")
-      case Right(obj) => println(s"Success!: ${obj.render(indent = 2)}")
+      case Left(e) => println(s"Failed: ${e.reason}")
+      case Right(results) =>
+        println(s"Success!")
+        results.foreach(result => println(s"Wrote to ${result.path}: ${result.content}"))
     }
   }
 
@@ -63,44 +62,27 @@ object Handler {
     )
   }
 
-  private val storeArticleInS3 = storeInS3(
-    s3 = S3Client
-      .builder()
-      .region(config.awsConfig.region)
-      .build(),
-    bucketName = config.awsConfig.bucketName,
-    folder = config.awsConfig.articlesFolder
-  ) _
+  private case class PutResult(path: String, content: String)
 
-  private def result(jsonString: String) = for {
-    input <- Try(read[InputModel](jsonString)).toEither.left.map(e =>
-      Failure(s"Failed to read article from input: ${e.getMessage}")
-    )
-    article = Article.fromInput(input.article)
-    json <- Right(toJson(article))
-    _ <- storeArticleInS3(s"${article.path}.json", json)
-  } yield json
+  private def result(jsonString: String): Either[Failure, Seq[PutResult]] = {
 
-  private def toJson(article: Article): ujson.Obj =
-    ujson.Obj(
-      "title" -> article.title,
-      "body" -> HtmlToJson(article.body),
-      "topics" -> article.topics.map(topic => ujson.Obj("path" -> topic.path, "title" -> topic.name))
-    )
+    def readInput(jsonString: String): Either[Failure, InputModel] =
+      Try(read[InputModel](jsonString)).toEither.left.map(e => Failure(s"Failed to read input: ${e.getMessage}"))
 
-  private def storeInS3(s3: S3Client, bucketName: String, folder: String)(
-      fileName: String,
-      content: ujson.Obj
-  ): Either[Failure, Unit] =
-    Try(
-      s3.putObject(
-        PutObjectRequest
-          .builder()
-          .bucket(bucketName)
-          .key(s"$folder/$fileName")
-          .contentType("application/json")
-          .build(),
-        RequestBody.fromString(content.render())
-      )
-    ).toEither.left.map(e => Failure(s"Failed to store '$fileName' in S3: ${e.getMessage}")).map(_ => ())
+    def writeArticle(article: Article): Either[Failure, String] =
+      Try(write(article)).toEither.left.map(e => Failure(s"Failed to write article: ${e.getMessage}"))
+
+    val s3 = S3Client.builder().region(config.awsConfig.region).build()
+
+    val putArticleInS3 =
+      S3.put(s3, bucketName = config.awsConfig.bucketName, folder = config.awsConfig.articlesFolder) _
+
+    for {
+      input <- readInput(jsonString)
+      article = Article.fromInput(input.article)
+      json <- writeArticle(article)
+      path = s"${article.path}.json"
+      _ <- putArticleInS3(path, json)
+    } yield Seq(PutResult(path, json))
+  }
 }

--- a/src/main/scala/managehelpcontentpublisher/HtmlToJson.scala
+++ b/src/main/scala/managehelpcontentpublisher/HtmlToJson.scala
@@ -63,7 +63,7 @@ object HtmlToJson {
     )(body)
   }
 
-  private def htmlToJson(n: Node): ujson.Obj =
+  private def htmlToJson(n: Node): ujson.Value =
     n match {
       case t: TextNode => ujson.Obj("element" -> "text", "content" -> t.text)
       case e: Element  => toJson(e)

--- a/src/main/scala/managehelpcontentpublisher/HtmlToJson.scala
+++ b/src/main/scala/managehelpcontentpublisher/HtmlToJson.scala
@@ -63,7 +63,7 @@ object HtmlToJson {
     )(body)
   }
 
-  private def htmlToJson(n: Node): ujson.Value =
+  private def htmlToJson(n: Node): ujson.Obj =
     n match {
       case t: TextNode => ujson.Obj("element" -> "text", "content" -> t.text)
       case e: Element  => toJson(e)

--- a/src/main/scala/managehelpcontentpublisher/InputModel.scala
+++ b/src/main/scala/managehelpcontentpublisher/InputModel.scala
@@ -19,7 +19,7 @@ object InputArticle {
   implicit val reader: Reader[InputArticle] = macroR
 }
 
-case class DataCategory(name: String)
+case class DataCategory(name: String, publishedArticles: Seq[InputArticle])
 
 object DataCategory {
   implicit val reader: Reader[DataCategory] = macroR

--- a/src/main/scala/managehelpcontentpublisher/PathAndContent.scala
+++ b/src/main/scala/managehelpcontentpublisher/PathAndContent.scala
@@ -1,0 +1,57 @@
+package managehelpcontentpublisher
+
+import managehelpcontentpublisher.Article.fromInput
+import upickle.default._
+
+import scala.util.Try
+
+case class PathAndContent(path: String, content: String)
+
+object PathAndContent {
+
+  /** Publishes the contents of the given Json string
+    * to representations of an Article and multiple Topics
+    * suitable to be rendered by a web layer.
+    *
+    * @param storeArticle Function that will store the new representation of an Article somewhere.
+    * @param storeTopic Function that will store the new representation of a Topic somewhere.
+    * @param jsonString A Json string holding all the data needed to publish an Article and its Topics.
+    * @return List of PathAndContents published.
+    *         The meaning of Path depends on the implementation of storeArticle and storeTopic.
+    */
+  def publishContents(
+      storeArticle: PathAndContent => Either[Failure, PathAndContent],
+      storeTopic: PathAndContent => Either[Failure, PathAndContent]
+  )(jsonString: String): Either[Failure, Seq[PathAndContent]] = {
+
+    def readInput(jsonString: String): Either[Failure, InputModel] =
+      Try(read[InputModel](jsonString)).toEither.left.map(e => Failure(s"Failed to read input: ${e.getMessage}"))
+
+    def publishArticle(article: Article): Either[Failure, PathAndContent] = {
+      def writeArticle(article: Article): Either[Failure, String] =
+        Try(write(article)).toEither.left.map(e => Failure(s"Failed to write article: ${e.getMessage}"))
+      for {
+        content <- writeArticle(article)
+        result <- storeArticle(PathAndContent(article.path, content))
+      } yield result
+    }
+
+    def publishTopic(topic: Topic): Either[Failure, PathAndContent] = {
+      def writeTopic(topic: Topic): Either[Failure, String] =
+        Try(write(topic)).toEither.left.map(e => Failure(s"Failed to write article: ${e.getMessage}"))
+      for {
+        content <- writeTopic(topic)
+        result <- storeTopic(PathAndContent(topic.path, content))
+      } yield result
+    }
+
+    def publishTopics(input: InputModel): Either[Failure, Seq[PathAndContent]] =
+      Eithers.seqToEither(Topic.fromInput(input).map(publishTopic))
+
+    for {
+      input <- readInput(jsonString)
+      articleResult <- publishArticle(fromInput(input.article))
+      topicResults <- publishTopics(input)
+    } yield Seq(articleResult) ++ topicResults
+  }
+}

--- a/src/main/scala/managehelpcontentpublisher/S3.scala
+++ b/src/main/scala/managehelpcontentpublisher/S3.scala
@@ -1,26 +1,57 @@
 package managehelpcontentpublisher
 
 import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.regions.Region.EU_WEST_1
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
 
+import scala.sys.env
 import scala.util.Try
 
 object S3 {
 
-  def put(s3: S3Client, bucketName: String, folder: String)(
-      fileName: String,
-      content: String
-  ): Either[Failure, Unit] =
+  private case class AwsConfig(region: Region, bucketName: String, articlesFolder: String, topicsFolder: String)
+  private case class Config(stage: String, awsConfig: AwsConfig)
+
+  private val config = {
+    val stage = env.getOrElse("stage", "DEV")
+    Config(
+      stage,
+      AwsConfig(
+        region = EU_WEST_1,
+        bucketName = "manage-help-content",
+        articlesFolder = s"$stage/articles",
+        topicsFolder = s"$stage/topics"
+      )
+    )
+  }
+
+  private val client = S3Client.builder().region(config.awsConfig.region).build()
+
+  private def put(folder: String)(fileName: String, content: String): Either[Failure, PathAndContent] = {
+    val key = s"$folder/$fileName"
+    val fullPath = s"${config.awsConfig.bucketName}/$key"
     Try(
-      s3.putObject(
+      client.putObject(
         PutObjectRequest
           .builder()
-          .bucket(bucketName)
-          .key(s"$folder/$fileName")
+          .bucket(config.awsConfig.bucketName)
+          .key(key)
           .contentType("application/json")
           .build(),
         RequestBody.fromString(content)
       )
-    ).toEither.left.map(e => Failure(s"Failed to store '$fileName' in S3: ${e.getMessage}")).map(_ => ())
+    ).toEither.left
+      .map(e => Failure(s"Failed to write to '$fullPath': ${e.getMessage}"))
+      .map(_ => PathAndContent(fullPath, content))
+  }
+
+  val putArticle: PathAndContent => Either[Failure, PathAndContent] = { article =>
+    put(config.awsConfig.articlesFolder)(article.path, article.content)
+  }
+
+  val putTopic: PathAndContent => Either[Failure, PathAndContent] = { topic =>
+    put(config.awsConfig.topicsFolder)(topic.path, topic.content)
+  }
 }

--- a/src/main/scala/managehelpcontentpublisher/S3.scala
+++ b/src/main/scala/managehelpcontentpublisher/S3.scala
@@ -1,0 +1,26 @@
+package managehelpcontentpublisher
+
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+
+import scala.util.Try
+
+object S3 {
+
+  def put(s3: S3Client, bucketName: String, folder: String)(
+      fileName: String,
+      content: String
+  ): Either[Failure, Unit] =
+    Try(
+      s3.putObject(
+        PutObjectRequest
+          .builder()
+          .bucket(bucketName)
+          .key(s"$folder/$fileName")
+          .contentType("application/json")
+          .build(),
+        RequestBody.fromString(content)
+      )
+    ).toEither.left.map(e => Failure(s"Failed to store '$fileName' in S3: ${e.getMessage}")).map(_ => ())
+}

--- a/src/main/scala/managehelpcontentpublisher/SalesforceCleaner.scala
+++ b/src/main/scala/managehelpcontentpublisher/SalesforceCleaner.scala
@@ -1,0 +1,5 @@
+package managehelpcontentpublisher
+
+object SalesforceCleaner {
+  def cleanCustomFieldName(name: String): String = name.stripSuffix("__c")
+}

--- a/src/main/scala/managehelpcontentpublisher/Topic.scala
+++ b/src/main/scala/managehelpcontentpublisher/Topic.scala
@@ -1,9 +1,33 @@
 package managehelpcontentpublisher
 
+import managehelpcontentpublisher.SalesforceCleaner.cleanCustomFieldName
 import upickle.default._
 
-case class Topic(path: String, name: String)
+case class Topic(path: String, title: String, articles: Seq[TopicArticle])
 
 object Topic {
-  implicit val reader: Reader[Topic] = macroR
+  implicit val writer: Writer[Topic] = macroW
+
+  def fromInput(input: InputModel): Seq[Topic] = {
+    val titles = input.article.dataCategories.map(cat => cat.name -> cat.label).toMap
+    input.dataCategories.map(cat =>
+      Topic(
+        path = cleanCustomFieldName(cat.name),
+        title = titles(cat.name),
+        articles = cat.publishedArticles.map(TopicArticle.fromInput).sortBy(_.title)
+      )
+    )
+  }
+}
+
+case class TopicArticle(path: String, title: String)
+
+object TopicArticle {
+
+  implicit val writer: Writer[TopicArticle] = macroW
+
+  def fromInput(input: InputArticle): TopicArticle = TopicArticle(
+    title = input.title,
+    path = input.urlName
+  )
 }

--- a/src/main/scala/managehelpcontentpublisher/Topic.scala
+++ b/src/main/scala/managehelpcontentpublisher/Topic.scala
@@ -1,11 +1,9 @@
 package managehelpcontentpublisher
 
+import upickle.default._
+
 case class Topic(path: String, name: String)
 
 object Topic {
-
-  def fromSalesforceDataCategory(cat: ArticleDataCategory): Topic = Topic(
-    path = cat.name.stripSuffix("__c"),
-    name = cat.label
-  )
+  implicit val reader: Reader[Topic] = macroR
 }

--- a/src/test/scala/managehelpcontentpublisher/PathAndContentTestSuite.scala
+++ b/src/test/scala/managehelpcontentpublisher/PathAndContentTestSuite.scala
@@ -1,0 +1,71 @@
+package managehelpcontentpublisher
+
+import utest._
+
+/** See [[https://github.com/guardian/salesforce/blob/master/force-app/main/default/classes/ArticleBodyValidation.cls#L5-L20 list of HTML elements we support in Salesforce]].
+  */
+object PathAndContentTestSuite extends TestSuite {
+
+  val tests: Tests = Tests {
+
+    test("Publish expected content") {
+      val publishContents = PathAndContent.publishContents(
+        { article => Right(PathAndContent(s"testArticles/${article.path}", article.content)) },
+        { topic => Right(PathAndContent(s"testTopics/${topic.path}", topic.content)) }
+      ) _
+      publishContents("""{
+                        |    "dataCategories": [
+                        |        {
+                        |            "publishedArticles": [
+                        |                {
+                        |                    "urlName": "id-like-to-make-a-complaint-about-an-advertisement",
+                        |                    "title": "I'd like to make a complaint about an advertisement",
+                        |                    "id": "id1",
+                        |                    "dataCategories": [],
+                        |                    "body": null
+                        |                },
+                        |                {
+                        |                    "urlName": "can-i-read-your-papermagazines-online",
+                        |                    "title": "Can I read your paper/magazines online?",
+                        |                    "id": "id2",
+                        |                    "dataCategories": [],
+                        |                    "body": null
+                        |                },
+                        |                {
+                        |                    "urlName": "im-unable-to-comment-and-need-help",
+                        |                    "title": "I'm unable to comment and need help",
+                        |                    "id": "id3",
+                        |                    "dataCategories": [],
+                        |                    "body": null
+                        |                }
+                        |            ],
+                        |            "name": "website__c"
+                        |        }
+                        |    ],
+                        |    "article": {
+                        |        "urlName": "can-i-read-your-papermagazines-online",
+                        |        "title": "Can I read your paper/magazines online?",
+                        |        "id": "id2",
+                        |        "dataCategories": [
+                        |            {
+                        |                "name": "website__c",
+                        |                "label": "The Guardian website"
+                        |            }
+                        |        ],
+                        |        "body": "<p>We do not</p>"
+                        |    }
+                        |}""".stripMargin) ==> Right(
+        Seq(
+          PathAndContent(
+            "testArticles/can-i-read-your-papermagazines-online",
+            """{"title":"Can I read your paper/magazines online?","body":[{"element":"p","content":[{"element":"text","content":"We do not"}]}],"path":"can-i-read-your-papermagazines-online","topics":[{"path":"website","title":"The Guardian website"}]}"""
+          ),
+          PathAndContent(
+            "testTopics/website",
+            """{"path":"website","title":"The Guardian website","articles":[{"path":"can-i-read-your-papermagazines-online","title":"Can I read your paper/magazines online?"},{"path":"id-like-to-make-a-complaint-about-an-advertisement","title":"I'd like to make a complaint about an advertisement"},{"path":"im-unable-to-comment-and-need-help","title":"I'm unable to comment and need help"}]}"""
+          )
+        )
+      )
+    }
+  }
+}


### PR DESCRIPTION
When we publish an Article, we also re-publish the content of the Topics that the Article falls into.  The list of Articles in a Topic is all the published Articles in that Topic ordered by title.

The Topic is published to the S3 bucket `manage-help-content` with key: `<stage>/topics/<topic-path>`.
Content is in the form:
```
{
  "path": "...",
  "title": "...",
  "articles": [
    {
      "path": "...",
      "title": "..."
    },
    ...
  ]
}
```

Publishing the `More topics` super-topic is still to come.
