### PR TITLE
Log entries as Json objects rather than strings

### DIFF
--- a/src/main/scala/managehelpcontentpublisher/Logging.scala
+++ b/src/main/scala/managehelpcontentpublisher/Logging.scala
@@ -1,0 +1,24 @@
+package managehelpcontentpublisher
+
+import com.amazonaws.services.lambda.runtime.Context
+import com.amazonaws.services.lambda.runtime.events.{APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent}
+
+object Logging {
+
+  private def log(context: Context, level: String, otherFields: ujson.Obj): Unit =
+    context.getLogger.log(ujson.Obj("logLevel" -> level, otherFields.value.toSeq: _*).render())
+
+  private def logInfo(context: Context, event: String, fields: ujson.Obj): Unit =
+    log(context, "INFO", ujson.Obj("event" -> event, fields.value.toSeq: _*))
+
+  def logError(context: Context, message: String): Unit = log(context, "ERROR", ujson.Obj("message" -> message))
+
+  def logRequest(context: Context, request: APIGatewayProxyRequestEvent): Unit =
+    logInfo(context, "Request", ujson.Obj("body" -> request.getBody))
+
+  def logResponse(context: Context, response: APIGatewayProxyResponseEvent): Unit =
+    logInfo(context, "Response", ujson.Obj("code" -> response.getStatusCode.toString, "body" -> response.getBody))
+
+  def logPublished(context: Context)(item: PathAndContent): Unit =
+    logInfo(context, "Published", ujson.Obj("path" -> item.path, "content" -> item.content))
+}

--- a/src/main/scala/managehelpcontentpublisher/Logging.scala
+++ b/src/main/scala/managehelpcontentpublisher/Logging.scala
@@ -2,23 +2,34 @@ package managehelpcontentpublisher
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.events.{APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent}
+import ujson.Obj
 
 object Logging {
 
-  private def log(context: Context, level: String, otherFields: ujson.Obj): Unit =
-    context.getLogger.log(ujson.Obj("logLevel" -> level, otherFields.value.toSeq: _*).render())
+  private def log(context: Context, level: String, otherFields: Obj): Unit =
+    context.getLogger.log(add(otherFields, "logLevel" -> level).render())
 
-  private def logInfo(context: Context, event: String, fields: ujson.Obj): Unit =
-    log(context, "INFO", ujson.Obj("event" -> event, fields.value.toSeq: _*))
+  private def logInfo(context: Context, event: String, fields: Obj): Unit =
+    log(context, "INFO", add(fields, "event" -> event))
 
-  def logError(context: Context, message: String): Unit = log(context, "ERROR", ujson.Obj("message" -> message))
+  def logError(context: Context, message: String): Unit = log(context, "ERROR", Obj("message" -> message))
 
   def logRequest(context: Context, request: APIGatewayProxyRequestEvent): Unit =
-    logInfo(context, "Request", ujson.Obj("body" -> request.getBody))
+    logInfo(context, "Request", Obj("body" -> request.getBody))
 
-  def logResponse(context: Context, response: APIGatewayProxyResponseEvent): Unit =
-    logInfo(context, "Response", ujson.Obj("code" -> response.getStatusCode.toString, "body" -> response.getBody))
+  def logResponse(context: Context, response: APIGatewayProxyResponseEvent): Unit = {
+    logInfo(
+      context,
+      "Response",
+      optionallyAdd(Obj("code" -> response.getStatusCode.toString), "body" -> Option(response.getBody))
+    )
+  }
 
   def logPublished(context: Context)(item: PathAndContent): Unit =
-    logInfo(context, "Published", ujson.Obj("path" -> item.path, "content" -> item.content))
+    logInfo(context, "Published", Obj("path" -> item.path, "content" -> item.content))
+
+  private def add(obj: Obj, field: (String, String)) = Obj(field, obj.value.toSeq: _*)
+
+  private def optionallyAdd(obj: Obj, field: (String, Option[String])) =
+    field._2.fold(obj)(value => add(obj, field._1 -> value))
 }


### PR DESCRIPTION
This change makes it easier to query and filter entries in Cloudwatch Insights.
Eg.
```
fields @timestamp, message
| filter event = 'Response' and code = 500
```

See https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CWL_AnalyzeLogData-discoverable-fields.html.
