### PR TITLE
Publish 'More topics' list

### DIFF
--- a/src/main/scala/managehelpcontentpublisher/Config.scala
+++ b/src/main/scala/managehelpcontentpublisher/Config.scala
@@ -1,0 +1,43 @@
+package managehelpcontentpublisher
+
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.regions.Region.EU_WEST_1
+
+import scala.sys.env
+
+case class Config(stage: String, topic: TopicConfig, aws: AwsConfig)
+
+case class TopicConfig(corePaths: Set[String], moreTopics: MoreTopicsConfig)
+
+case class MoreTopicsConfig(path: String, title: String)
+
+case class AwsConfig(region: Region, bucketName: String, articlesFolder: String, topicsFolder: String)
+
+object Config {
+
+  private val stage = env.getOrElse("stage", "DEV")
+
+  val config: Config = Config(
+    stage,
+    TopicConfig(
+      corePaths = Set(
+        "billing",
+        "delivery",
+        "accounts",
+        "journalism",
+        "subscriptions",
+        "website"
+      ),
+      moreTopics = MoreTopicsConfig(
+        path = "more-topics",
+        title = "More topics"
+      )
+    ),
+    AwsConfig(
+      region = EU_WEST_1,
+      bucketName = "manage-help-content",
+      articlesFolder = s"$stage/articles",
+      topicsFolder = s"$stage/topics"
+    )
+  )
+}

--- a/src/main/scala/managehelpcontentpublisher/Eithers.scala
+++ b/src/main/scala/managehelpcontentpublisher/Eithers.scala
@@ -6,4 +6,10 @@ object Eithers {
     eithers
       .collectFirst { case Left(e) => Left(e) }
       .getOrElse { Right(eithers.collect { case Right(a) => a }) }
+
+  def optionToEither[E, A](optEither: Option[Either[E, A]]): Either[E, Option[A]] =
+    optEither match {
+      case None         => Right(None)
+      case Some(either) => either.map(Some(_))
+    }
 }

--- a/src/main/scala/managehelpcontentpublisher/Handler.scala
+++ b/src/main/scala/managehelpcontentpublisher/Handler.scala
@@ -31,10 +31,10 @@ object Handler {
       case Left(e) => println(s"Failed: ${e.reason}")
       case Right(published) =>
         println(s"Success!")
-        published.foreach(item => println(s"Wrote to '${item.path}': ${item.content}"))
+        published.foreach(item => println(s"Wrote to ${item.path}: ${item.content}"))
     }
   }
 
   private def publishContents(jsonString: String): Either[Failure, Seq[PathAndContent]] =
-    PathAndContent.publishContents(S3.putArticle, S3.putTopic)(jsonString)
+    PathAndContent.publishContents(S3.putArticle, S3.putTopic, S3.fetchMoreTopics())(jsonString)
 }

--- a/src/main/scala/managehelpcontentpublisher/MoreTopics.scala
+++ b/src/main/scala/managehelpcontentpublisher/MoreTopics.scala
@@ -1,0 +1,38 @@
+package managehelpcontentpublisher
+
+import managehelpcontentpublisher.Config.config
+import upickle.default._
+
+/** A compilation of published articles by topic in the non-core topics.
+  */
+case class MoreTopics(path: String, title: String, topics: Seq[Topic])
+
+object MoreTopics {
+
+  implicit val rw: ReadWriter[MoreTopics] = macroRW
+
+  def apply(topics: Seq[Topic]): MoreTopics = MoreTopics(
+    path = config.topic.moreTopics.path,
+    title = config.topic.moreTopics.title,
+    topics
+  )
+
+  /** Creates new MoreTopics with a combination of the existing topic lists and the given new topic lists.
+    * Core topics are not included in MoreTopics.
+    *
+    * @param oldMoreTopics Base for the new MoreTopics if there is a pre-existing instance.
+    * @param newTopics New topic lists to add to the base list, replacing any lists with the same paths.
+    * @return New instance combining the old instance and the new lists.
+    */
+  def withNewTopics(oldMoreTopics: Option[MoreTopics], newTopics: Seq[Topic]): Option[MoreTopics] = {
+    def toMap(topics: Seq[Topic]) = topics.map(topic => topic.path -> topic).toMap
+    val topics = oldMoreTopics
+      .fold(newTopics) { moreTopics =>
+        val combinedTopics = toMap(moreTopics.topics) ++ toMap(newTopics)
+        combinedTopics.values.toSeq
+      }
+      .filterNot(topic => config.topic.corePaths.contains(topic.path))
+      .sortBy(_.title)
+    if (topics.isEmpty) None else Some(MoreTopics(topics))
+  }
+}

--- a/src/main/scala/managehelpcontentpublisher/PathAndContent.scala
+++ b/src/main/scala/managehelpcontentpublisher/PathAndContent.scala
@@ -1,6 +1,7 @@
 package managehelpcontentpublisher
 
 import managehelpcontentpublisher.Article.fromInput
+import managehelpcontentpublisher.Eithers._
 import upickle.default._
 
 import scala.util.Try
@@ -15,13 +16,16 @@ object PathAndContent {
     *
     * @param storeArticle Function that will store the new representation of an Article somewhere.
     * @param storeTopic Function that will store the new representation of a Topic somewhere.
+    * @param fetchMoreTopics Function that fetches the pre-existing state of More topics
+    *                        or None if there isn't an existing state.
     * @param jsonString A Json string holding all the data needed to publish an Article and its Topics.
     * @return List of PathAndContents published.
     *         The meaning of Path depends on the implementation of storeArticle and storeTopic.
     */
   def publishContents(
       storeArticle: PathAndContent => Either[Failure, PathAndContent],
-      storeTopic: PathAndContent => Either[Failure, PathAndContent]
+      storeTopic: PathAndContent => Either[Failure, PathAndContent],
+      fetchMoreTopics: => Either[Failure, Option[String]]
   )(jsonString: String): Either[Failure, Seq[PathAndContent]] = {
 
     def readInput(jsonString: String): Either[Failure, InputModel] =
@@ -45,13 +49,39 @@ object PathAndContent {
       } yield result
     }
 
-    def publishTopics(input: InputModel): Either[Failure, Seq[PathAndContent]] =
-      Eithers.seqToEither(Topic.fromInput(input).map(publishTopic))
+    def publishTopics(topics: Seq[Topic]): Either[Failure, Seq[PathAndContent]] =
+      Eithers.seqToEither(topics.map(publishTopic))
+
+    def publishMoreTopics(articleTopics: Seq[Topic]): Either[Failure, Option[PathAndContent]] = {
+
+      def readMoreTopics(jsonString: String): Either[Failure, MoreTopics] =
+        Try(read[MoreTopics](jsonString)).toEither.left.map(e =>
+          Failure(s"Failed to read more topics from '$jsonString': ${e.getMessage}")
+        )
+
+      def writeMoreTopics(moreTopics: MoreTopics): Either[Failure, String] =
+        Try(write(moreTopics)).toEither.left.map(e => Failure(s"Failed to write $moreTopics: ${e.getMessage}"))
+
+      def storeMoreTopics(prevMoreTopics: Option[MoreTopics], newContent: Option[String]) = for {
+        moreTopics <- prevMoreTopics
+        content <- newContent
+      } yield storeTopic(PathAndContent(moreTopics.path, content))
+
+      for {
+        jsonString <- fetchMoreTopics
+        oldMoreTopics <- optionToEither(jsonString.map(readMoreTopics))
+        newMoreTopics = MoreTopics.withNewTopics(oldMoreTopics, articleTopics)
+        content <- optionToEither(newMoreTopics.map(writeMoreTopics))
+        result <- optionToEither(storeMoreTopics(newMoreTopics, content))
+      } yield result
+    }
 
     for {
       input <- readInput(jsonString)
       articleResult <- publishArticle(fromInput(input.article))
-      topicResults <- publishTopics(input)
-    } yield Seq(articleResult) ++ topicResults
+      topics = Topic.fromInput(input)
+      topicResults <- publishTopics(topics)
+      moreTopicsResult <- publishMoreTopics(topics)
+    } yield Seq(articleResult) ++ topicResults ++ moreTopicsResult.toSeq
   }
 }

--- a/src/main/scala/managehelpcontentpublisher/Topic.scala
+++ b/src/main/scala/managehelpcontentpublisher/Topic.scala
@@ -6,7 +6,7 @@ import upickle.default._
 case class Topic(path: String, title: String, articles: Seq[TopicArticle])
 
 object Topic {
-  implicit val writer: Writer[Topic] = macroW
+  implicit val rw: ReadWriter[Topic] = macroRW
 
   def fromInput(input: InputModel): Seq[Topic] = {
     val titles = input.article.dataCategories.map(cat => cat.name -> cat.label).toMap
@@ -24,7 +24,7 @@ case class TopicArticle(path: String, title: String)
 
 object TopicArticle {
 
-  implicit val writer: Writer[TopicArticle] = macroW
+  implicit val rw: ReadWriter[TopicArticle] = macroRW
 
   def fromInput(input: InputArticle): TopicArticle = TopicArticle(
     title = input.title,

--- a/src/test/scala/managehelpcontentpublisher/PathAndContentTestSuite.scala
+++ b/src/test/scala/managehelpcontentpublisher/PathAndContentTestSuite.scala
@@ -6,14 +6,16 @@ import utest._
   */
 object PathAndContentTestSuite extends TestSuite {
 
+  private def publishContents(previousMoreTopics: Option[String]) = PathAndContent.publishContents(
+    { article => Right(PathAndContent(s"testArticles/${article.path}", article.content)) },
+    { topic => Right(PathAndContent(s"testTopics/${topic.path}", topic.content)) },
+    fetchMoreTopics = Right(previousMoreTopics)
+  ) _
+
   val tests: Tests = Tests {
 
-    test("Publish expected content") {
-      val publishContents = PathAndContent.publishContents(
-        { article => Right(PathAndContent(s"testArticles/${article.path}", article.content)) },
-        { topic => Right(PathAndContent(s"testTopics/${topic.path}", topic.content)) }
-      ) _
-      publishContents("""{
+    test("Publish when article has a core topic") {
+      val published = publishContents(None)("""{
                         |    "dataCategories": [
                         |        {
                         |            "publishedArticles": [
@@ -54,18 +56,257 @@ object PathAndContentTestSuite extends TestSuite {
                         |        ],
                         |        "body": "<p>We do not</p>"
                         |    }
-                        |}""".stripMargin) ==> Right(
-        Seq(
+                        |}""".stripMargin)
+      test("number of files published") {
+        published.map(_.length) ==> Right(2)
+      }
+      test("article published") {
+        published.map(_(0)) ==> Right(
           PathAndContent(
             "testArticles/can-i-read-your-papermagazines-online",
             """{"title":"Can I read your paper/magazines online?","body":[{"element":"p","content":[{"element":"text","content":"We do not"}]}],"path":"can-i-read-your-papermagazines-online","topics":[{"path":"website","title":"The Guardian website"}]}"""
-          ),
+          )
+        )
+      }
+      test("topic published") {
+        published.map(_(1)) ==> Right(
           PathAndContent(
             "testTopics/website",
             """{"path":"website","title":"The Guardian website","articles":[{"path":"can-i-read-your-papermagazines-online","title":"Can I read your paper/magazines online?"},{"path":"id-like-to-make-a-complaint-about-an-advertisement","title":"I'd like to make a complaint about an advertisement"},{"path":"im-unable-to-comment-and-need-help","title":"I'm unable to comment and need help"}]}"""
           )
         )
-      )
+      }
+    }
+
+    test("Publish when article has a non-core topic and 'More topics' is empty") {
+      val published = publishContents(None)("""{
+          |    "dataCategories": [
+          |        {
+          |            "publishedArticles": [
+          |                {
+          |                    "urlName": "id-like-to-make-a-complaint-about-an-advertisement",
+          |                    "title": "I'd like to make a complaint about an advertisement",
+          |                    "id": "id1",
+          |                    "dataCategories": [],
+          |                    "body": null
+          |                },
+          |                {
+          |                    "urlName": "can-i-read-your-papermagazines-online",
+          |                    "title": "Can I read your paper/magazines online?",
+          |                    "id": "id2",
+          |                    "dataCategories": [],
+          |                    "body": null
+          |                },
+          |                {
+          |                    "urlName": "im-unable-to-comment-and-need-help",
+          |                    "title": "I'm unable to comment and need help",
+          |                    "id": "id3",
+          |                    "dataCategories": [],
+          |                    "body": null
+          |                }
+          |            ],
+          |            "name": "archives__c"
+          |        }
+          |    ],
+          |    "article": {
+          |        "urlName": "can-i-read-your-papermagazines-online",
+          |        "title": "Can I read your paper/magazines online?",
+          |        "id": "id2",
+          |        "dataCategories": [
+          |            {
+          |                "name": "archives__c",
+          |                "label": "Back issues and archives"
+          |            }
+          |        ],
+          |        "body": "<p>We do not</p>"
+          |    }
+          |}""".stripMargin)
+      test("number of files published") {
+        published.map(_.length) ==> Right(3)
+      }
+      test("article published") {
+        published.map(_(0)) ==> Right(
+          PathAndContent(
+            "testArticles/can-i-read-your-papermagazines-online",
+            """{"title":"Can I read your paper/magazines online?","body":[{"element":"p","content":[{"element":"text","content":"We do not"}]}],"path":"can-i-read-your-papermagazines-online","topics":[{"path":"archives","title":"Back issues and archives"}]}"""
+          )
+        )
+      }
+      test("topic published") {
+        published.map(_(1)) ==> Right(
+          PathAndContent(
+            "testTopics/archives",
+            """{"path":"archives","title":"Back issues and archives","articles":[{"path":"can-i-read-your-papermagazines-online","title":"Can I read your paper/magazines online?"},{"path":"id-like-to-make-a-complaint-about-an-advertisement","title":"I'd like to make a complaint about an advertisement"},{"path":"im-unable-to-comment-and-need-help","title":"I'm unable to comment and need help"}]}"""
+          )
+        )
+      }
+      test("More topics published") {
+        published.map(_(2)) ==> Right(
+          PathAndContent(
+            "testTopics/more-topics",
+            """{"path":"more-topics","title":"More topics","topics":[{"path":"archives","title":"Back issues and archives","articles":[{"path":"can-i-read-your-papermagazines-online","title":"Can I read your paper/magazines online?"},{"path":"id-like-to-make-a-complaint-about-an-advertisement","title":"I'd like to make a complaint about an advertisement"},{"path":"im-unable-to-comment-and-need-help","title":"I'm unable to comment and need help"}]}]}"""
+          )
+        )
+      }
+    }
+
+    test("Publish article, topic and more topics when article has a non-core topic and 'More topics' is not empty") {
+      val previousMoreTopics = """{
+                                 |  "path": "more-topics",
+                                 |  "title": "More Topics",
+                                 |  "topics": [
+                                 |    {
+                                 |      "path": "the-guardian-apps",
+                                 |      "title": "The Guardian apps",
+                                 |      "articles": [
+                                 |        {
+                                 |          "path": "a1",
+                                 |          "title": "Premium tier access"
+                                 |        },
+                                 |        {
+                                 |          "path": "a2",
+                                 |          "title": "Apple/Google subscriptions"
+                                 |        },
+                                 |        {
+                                 |          "path": "a3",
+                                 |          "title": "Personalising your apps"
+                                 |        }
+                                 |      ]
+                                 |    },
+                                 |    {
+                                 |      "path": "newsletters-and-emails",
+                                 |      "title": "Newsletters and emails",
+                                 |      "articles": [
+                                 |        {
+                                 |          "path": "n1",
+                                 |          "title": "I'm not receiving any emails from you but think I should be"
+                                 |        },
+                                 |        {
+                                 |          "path": "n2",
+                                 |          "title": "Manage your email preferences"
+                                 |        }
+                                 |      ]
+                                 |    },
+                                 |    {
+                                 |      "path": "events",
+                                 |      "title": "Events",
+                                 |      "articles": [
+                                 |        {
+                                 |          "path": "e1",
+                                 |          "title":
+                                 |            "I can no longer attend the live online event, can I have a refund?"
+                                 |        },
+                                 |        {
+                                 |          "path": "e2",
+                                 |          "title":
+                                 |            "I can’t find my original confirmation email, can you resend me the event link?"
+                                 |        },
+                                 |        {
+                                 |          "path": "e3",
+                                 |          "title":
+                                 |            "Once I have purchased a ticket, how will I attend the online event?"
+                                 |        },
+                                 |        {
+                                 |          "path": "e4",
+                                 |          "title": "I purchased a book with my ticket, when will I receive this?"
+                                 |        }
+                                 |      ]
+                                 |    },
+                                 |    {
+                                 |      "path": "gifting",
+                                 |      "title": "Gifting",
+                                 |      "articles": [
+                                 |        {
+                                 |          "path": "g1",
+                                 |          "title": "Gifting a Digital Subscription"
+                                 |        }
+                                 |      ]
+                                 |    },
+                                 |    {
+                                 |      "path": "archives",
+                                 |      "title": "Back issues and archives",
+                                 |      "articles": [
+                                 |        {
+                                 |          "path": "b1",
+                                 |          "title": "Finding articles from the past in digital format"
+                                 |        },
+                                 |        {
+                                 |          "path": "b2",
+                                 |          "title": "Old newspapers in physical format"
+                                 |        }
+                                 |      ]
+                                 |    }
+                                 |  ]
+                                 |}""".stripMargin
+      val published = publishContents(Some(previousMoreTopics))("""{
+                                        |    "dataCategories": [
+                                        |        {
+                                        |            "publishedArticles": [
+                                        |                {
+                                        |                    "urlName": "id-like-to-make-a-complaint-about-an-advertisement",
+                                        |                    "title": "I'd like to make a complaint about an advertisement",
+                                        |                    "id": "id1",
+                                        |                    "dataCategories": [],
+                                        |                    "body": null
+                                        |                },
+                                        |                {
+                                        |                    "urlName": "can-i-read-your-papermagazines-online",
+                                        |                    "title": "Can I read your paper/magazines online?",
+                                        |                    "id": "id2",
+                                        |                    "dataCategories": [],
+                                        |                    "body": null
+                                        |                },
+                                        |                {
+                                        |                    "urlName": "im-unable-to-comment-and-need-help",
+                                        |                    "title": "I'm unable to comment and need help",
+                                        |                    "id": "id3",
+                                        |                    "dataCategories": [],
+                                        |                    "body": null
+                                        |                }
+                                        |            ],
+                                        |            "name": "archives__c"
+                                        |        }
+                                        |    ],
+                                        |    "article": {
+                                        |        "urlName": "can-i-read-your-papermagazines-online",
+                                        |        "title": "Can I read your paper/magazines online?",
+                                        |        "id": "id2",
+                                        |        "dataCategories": [
+                                        |            {
+                                        |                "name": "archives__c",
+                                        |                "label": "Back issues and archives"
+                                        |            }
+                                        |        ],
+                                        |        "body": "<p>We do not</p>"
+                                        |    }
+                                        |}""".stripMargin)
+      test("number of files published") {
+        published.map(_.length) ==> Right(3)
+      }
+      test("article published") {
+        published.map(_(0)) ==> Right(
+          PathAndContent(
+            "testArticles/can-i-read-your-papermagazines-online",
+            """{"title":"Can I read your paper/magazines online?","body":[{"element":"p","content":[{"element":"text","content":"We do not"}]}],"path":"can-i-read-your-papermagazines-online","topics":[{"path":"archives","title":"Back issues and archives"}]}"""
+          )
+        )
+      }
+      test("topic published") {
+        published.map(_(1)) ==> Right(
+          PathAndContent(
+            "testTopics/archives",
+            """{"path":"archives","title":"Back issues and archives","articles":[{"path":"can-i-read-your-papermagazines-online","title":"Can I read your paper/magazines online?"},{"path":"id-like-to-make-a-complaint-about-an-advertisement","title":"I'd like to make a complaint about an advertisement"},{"path":"im-unable-to-comment-and-need-help","title":"I'm unable to comment and need help"}]}"""
+          )
+        )
+      }
+      test("More topics published") {
+        published.map(_(2)) ==> Right(
+          PathAndContent(
+            "testTopics/more-topics",
+            """{"path":"more-topics","title":"More topics","topics":[{"path":"archives","title":"Back issues and archives","articles":[{"path":"can-i-read-your-papermagazines-online","title":"Can I read your paper/magazines online?"},{"path":"id-like-to-make-a-complaint-about-an-advertisement","title":"I'd like to make a complaint about an advertisement"},{"path":"im-unable-to-comment-and-need-help","title":"I'm unable to comment and need help"}]},{"path":"events","title":"Events","articles":[{"path":"e1","title":"I can no longer attend the live online event, can I have a refund?"},{"path":"e2","title":"I can’t find my original confirmation email, can you resend me the event link?"},{"path":"e3","title":"Once I have purchased a ticket, how will I attend the online event?"},{"path":"e4","title":"I purchased a book with my ticket, when will I receive this?"}]},{"path":"gifting","title":"Gifting","articles":[{"path":"g1","title":"Gifting a Digital Subscription"}]},{"path":"newsletters-and-emails","title":"Newsletters and emails","articles":[{"path":"n1","title":"I'm not receiving any emails from you but think I should be"},{"path":"n2","title":"Manage your email preferences"}]},{"path":"the-guardian-apps","title":"The Guardian apps","articles":[{"path":"a1","title":"Premium tier access"},{"path":"a2","title":"Apple/Google subscriptions"},{"path":"a3","title":"Personalising your apps"}]}]}"""
+          )
+        )
+      }
     }
   }
 }


### PR DESCRIPTION
We have a '[More topics](https://github.com/guardian/manage-help-content-publisher/compare/kc-more-topics?expand=1#diff-1d0bf09b6013ac73a4f0d92c285717b5cb83feb485f23a222f472f1119f89df9R8)' topic which is a compilation of all the published articles by topic in the non-[core](https://github.com/guardian/manage-help-content-publisher/compare/kc-more-topics?expand=1#diff-12a1907d64e37d3a23feef5d4d336d09f522325dc3d91fbf3c3ce2867be1731dR23-R30) topics.

This PR creates or updates the More topics list when an article is published.  It does this by [taking the existing list, if any, and overwriting any topics in it to which the published article belongs](https://github.com/guardian/manage-help-content-publisher/compare/kc-more-topics?expand=1#diff-1d0bf09b6013ac73a4f0d92c285717b5cb83feb485f23a222f472f1119f89df9R27-R37).

What I haven't considered yet is what happens when an article is removed from a topic.  This is a problem for publishing topic pages generally as well as the more topics.  That will be considered in a separate PR.

Because of the non-transactional nature of S3, there's a small possibility that a conflict might cause inconsistent results.  This would happen if two editors both published different articles more or less simultaneously.  It seems like a very small risk for our case though and would be easy to resolve if it happened.
