### PR TITLE
When a topic is removed from an article, republish the topic page without the article

### DIFF
--- a/src/main/scala/managehelpcontentpublisher/Article.scala
+++ b/src/main/scala/managehelpcontentpublisher/Article.scala
@@ -32,5 +32,5 @@ object ArticleTopic {
     * If there is no previous version, gives an empty list.
     */
   def topicsArticleRemovedFrom(curr: Article, prev: Option[Article]): Seq[ArticleTopic] =
-    prev.map(_.topics.filterNot(curr.topics.contains)).getOrElse(Nil)
+    prev.map(_.topics.diff(curr.topics)).getOrElse(Nil)
 }

--- a/src/main/scala/managehelpcontentpublisher/Article.scala
+++ b/src/main/scala/managehelpcontentpublisher/Article.scala
@@ -7,7 +7,7 @@ case class Article(title: String, body: ujson.Value, path: String, topics: Seq[A
 
 object Article {
 
-  implicit val writer: Writer[Article] = macroW
+  implicit val rw: ReadWriter[Article] = macroRW
 
   def fromInput(input: InputArticle): Article = Article(
     title = input.title,
@@ -21,10 +21,16 @@ case class ArticleTopic(path: String, title: String)
 
 object ArticleTopic {
 
-  implicit val writer: Writer[ArticleTopic] = macroW
+  implicit val rw: ReadWriter[ArticleTopic] = macroRW
 
   def fromSalesforceDataCategory(cat: ArticleDataCategory): ArticleTopic = ArticleTopic(
     path = cleanCustomFieldName(cat.name),
     title = cat.label
   )
+
+  /** Gives the list of topics that have been removed between the two given versions of an article.
+    * If there is no previous version, gives an empty list.
+    */
+  def topicsArticleRemovedFrom(curr: Article, prev: Option[Article]): Seq[ArticleTopic] =
+    prev.map(_.topics.filterNot(curr.topics.contains)).getOrElse(Nil)
 }

--- a/src/main/scala/managehelpcontentpublisher/Handler.scala
+++ b/src/main/scala/managehelpcontentpublisher/Handler.scala
@@ -36,5 +36,5 @@ object Handler {
   }
 
   private def publishContents(jsonString: String): Either[Failure, Seq[PathAndContent]] =
-    PathAndContent.publishContents(S3.putArticle, S3.putTopic, S3.fetchMoreTopics())(jsonString)
+    PathAndContent.publishContents(S3.fetchArticleByPath, S3.fetchTopicByPath, S3.putArticle, S3.putTopic)(jsonString)
 }

--- a/src/main/scala/managehelpcontentpublisher/PathAndContent.scala
+++ b/src/main/scala/managehelpcontentpublisher/PathAndContent.scala
@@ -1,6 +1,7 @@
 package managehelpcontentpublisher
 
 import managehelpcontentpublisher.Article.fromInput
+import managehelpcontentpublisher.Config.config
 import managehelpcontentpublisher.Eithers._
 import upickle.default._
 
@@ -14,22 +15,31 @@ object PathAndContent {
     * to representations of an Article and multiple Topics
     * suitable to be rendered by a web layer.
     *
+    * @param fetchArticleByPath Function that fetches the current state of the published article with the given path
+    *                        or None if there is no such article.
+    * @param fetchTopicByPath Function that fetches the current state of the published topic with the given path
+    *                        or None if there is no such topic.
     * @param storeArticle Function that will store the new representation of an Article somewhere.
     * @param storeTopic Function that will store the new representation of a Topic somewhere.
-    * @param fetchMoreTopics Function that fetches the pre-existing state of More topics
-    *                        or None if there isn't an existing state.
     * @param jsonString A Json string holding all the data needed to publish an Article and its Topics.
     * @return List of PathAndContents published.
     *         The meaning of Path depends on the implementation of storeArticle and storeTopic.
     */
   def publishContents(
+      fetchArticleByPath: String => Either[Failure, Option[String]],
+      fetchTopicByPath: String => Either[Failure, Option[String]],
       storeArticle: PathAndContent => Either[Failure, PathAndContent],
-      storeTopic: PathAndContent => Either[Failure, PathAndContent],
-      fetchMoreTopics: => Either[Failure, Option[String]]
+      storeTopic: PathAndContent => Either[Failure, PathAndContent]
   )(jsonString: String): Either[Failure, Seq[PathAndContent]] = {
 
     def readInput(jsonString: String): Either[Failure, InputModel] =
       Try(read[InputModel](jsonString)).toEither.left.map(e => Failure(s"Failed to read input: ${e.getMessage}"))
+
+    def readArticle(jsonString: String): Either[Failure, Article] =
+      Try(read[Article](jsonString)).toEither.left.map(e => Failure(s"Failed to read article: ${e.getMessage}"))
+
+    def writeTopic(topic: Topic): Either[Failure, String] =
+      Try(write(topic)).toEither.left.map(e => Failure(s"Failed to write topic: ${e.getMessage}"))
 
     def publishArticle(article: Article): Either[Failure, PathAndContent] = {
       def writeArticle(article: Article): Either[Failure, String] =
@@ -41,16 +51,30 @@ object PathAndContent {
     }
 
     def publishTopic(topic: Topic): Either[Failure, PathAndContent] = {
-      def writeTopic(topic: Topic): Either[Failure, String] =
-        Try(write(topic)).toEither.left.map(e => Failure(s"Failed to write article: ${e.getMessage}"))
       for {
         content <- writeTopic(topic)
         result <- storeTopic(PathAndContent(topic.path, content))
       } yield result
     }
 
+    def removeFromTopics(article: Article, topics: Seq[ArticleTopic]): Either[Failure, Seq[PathAndContent]] =
+      seqToEither(topics.map(removeFromTopic(article))).map(_.flatten)
+
+    def removeFromTopic(article: Article)(articleTopic: ArticleTopic): Either[Failure, Option[PathAndContent]] = {
+
+      def readTopic(jsonString: String): Either[Failure, Topic] =
+        Try(read[Topic](jsonString)).toEither.left.map(e => Failure(s"Failed to read topic: ${e.getMessage}"))
+
+      for {
+        oldTopicJson <- fetchTopicByPath(articleTopic.path)
+        oldTopic <- optionToEither(oldTopicJson.map(readTopic))
+        newTopicJson <- optionToEither(oldTopic.map(Topic.removeFromTopic(article)).map(writeTopic))
+        newTopic <- optionToEither(newTopicJson.map(content => storeTopic(PathAndContent(articleTopic.path, content))))
+      } yield newTopic
+    }
+
     def publishTopics(topics: Seq[Topic]): Either[Failure, Seq[PathAndContent]] =
-      Eithers.seqToEither(topics.map(publishTopic))
+      seqToEither(topics.map(publishTopic))
 
     def publishMoreTopics(articleTopics: Seq[Topic]): Either[Failure, Option[PathAndContent]] = {
 
@@ -67,21 +91,30 @@ object PathAndContent {
         content <- newContent
       } yield storeTopic(PathAndContent(moreTopics.path, content))
 
-      for {
-        jsonString <- fetchMoreTopics
-        oldMoreTopics <- optionToEither(jsonString.map(readMoreTopics))
-        newMoreTopics = MoreTopics.withNewTopics(oldMoreTopics, articleTopics)
-        content <- optionToEither(newMoreTopics.map(writeMoreTopics))
-        result <- optionToEither(storeMoreTopics(newMoreTopics, content))
-      } yield result
+      if (articleTopics.forall(topic => config.topic.corePaths.contains(topic.path))) Right(None)
+      else
+        for {
+          jsonString <- fetchTopicByPath(config.topic.moreTopics.path)
+          oldMoreTopics <- optionToEither(jsonString.map(readMoreTopics))
+          newMoreTopics = MoreTopics.withNewTopics(oldMoreTopics, articleTopics)
+          content <- optionToEither(newMoreTopics.map(writeMoreTopics))
+          result <- optionToEither(storeMoreTopics(newMoreTopics, content))
+        } yield result
     }
 
     for {
       input <- readInput(jsonString)
-      articleResult <- publishArticle(fromInput(input.article))
+      newArticle = fromInput(input.article)
+      oldArticleJson <- fetchArticleByPath(newArticle.path)
+      oldArticle <- optionToEither(oldArticleJson.map(readArticle))
+      publishedArticle <- publishArticle(newArticle)
       topics = Topic.fromInput(input)
-      topicResults <- publishTopics(topics)
-      moreTopicsResult <- publishMoreTopics(topics)
-    } yield Seq(articleResult) ++ topicResults ++ moreTopicsResult.toSeq
+      publishedTopics <- publishTopics(topics)
+      publishedMoreTopics <- publishMoreTopics(topics)
+      topicsArticleRemovedFrom <- removeFromTopics(
+        newArticle,
+        ArticleTopic.topicsArticleRemovedFrom(newArticle, oldArticle)
+      )
+    } yield Seq(publishedArticle) ++ publishedTopics ++ publishedMoreTopics.toSeq ++ topicsArticleRemovedFrom
   }
 }

--- a/src/main/scala/managehelpcontentpublisher/S3.scala
+++ b/src/main/scala/managehelpcontentpublisher/S3.scala
@@ -31,6 +31,12 @@ object S3 {
         case e                     => Left(Failure(s"Failed to get s3://${config.aws.bucketName}/$key: ${e.getMessage}"))
       }
 
+  def fetchArticleByPath(path: String): Either[Failure, Option[String]] =
+    get(s"${config.aws.articlesFolder}/$path.json")
+
+  def fetchTopicByPath(path: String): Either[Failure, Option[String]] =
+    get(s"${config.aws.topicsFolder}/$path.json")
+
   private def put(key: String, content: String): Either[Failure, PathAndContent] = {
     val fullPath = s"s3://${config.aws.bucketName}/$key"
     Try(
@@ -53,7 +59,4 @@ object S3 {
 
   def putTopic(topic: PathAndContent): Either[Failure, PathAndContent] =
     put(s"${config.aws.topicsFolder}/${topic.path}.json", topic.content)
-
-  def fetchMoreTopics(): Either[Failure, Option[String]] =
-    get(s"${config.aws.topicsFolder}/${config.topic.moreTopics.path}.json")
 }

--- a/src/main/scala/managehelpcontentpublisher/Topic.scala
+++ b/src/main/scala/managehelpcontentpublisher/Topic.scala
@@ -18,6 +18,9 @@ object Topic {
       )
     )
   }
+
+  def removeFromTopic(article: Article)(topic: Topic): Topic =
+    topic.copy(articles = topic.articles.filterNot(_.path == article.path))
 }
 
 case class TopicArticle(path: String, title: String)

--- a/src/test/scala/managehelpcontentpublisher/ArticleTopicTest.scala
+++ b/src/test/scala/managehelpcontentpublisher/ArticleTopicTest.scala
@@ -1,0 +1,55 @@
+package managehelpcontentpublisher
+
+import utest._
+
+object ArticleTopicTest extends TestSuite {
+
+  object Fixtures {
+
+    val billingTopic: ArticleTopic = ArticleTopic("billing", "Billing")
+    val deliveryTopic: ArticleTopic = ArticleTopic("delivery", "Delivery")
+
+    def mkArticle(topics: ArticleTopic*): Article = Article(
+      title = "t",
+      body = ujson.Str("body"),
+      path = "p",
+      topics
+    )
+  }
+
+  def tests: Tests = Tests {
+    import Fixtures._
+
+    test("topicsArticleRemovedFrom") {
+      test("when article hasn't been removed from any topics") {
+        val prev = mkArticle(billingTopic)
+        val curr = mkArticle(billingTopic)
+        ArticleTopic.topicsArticleRemovedFrom(curr, Some(prev)) ==> Nil
+      }
+      test("when article has been removed from a topic") {
+        val prev = mkArticle(deliveryTopic)
+        val curr = mkArticle(billingTopic)
+        ArticleTopic.topicsArticleRemovedFrom(curr, Some(prev)) ==> Seq(deliveryTopic)
+      }
+      test("when article has been removed from multiple topics") {
+        val prev = mkArticle(billingTopic, deliveryTopic)
+        val curr = mkArticle()
+        ArticleTopic.topicsArticleRemovedFrom(curr, Some(prev)) ==> Seq(billingTopic, deliveryTopic)
+      }
+      test("when some topics have been added") {
+        val prev = mkArticle()
+        val curr = mkArticle(billingTopic, deliveryTopic)
+        ArticleTopic.topicsArticleRemovedFrom(curr, Some(prev)) ==> Nil
+      }
+      test("when some topics have been added and removed") {
+        val prev = mkArticle(deliveryTopic)
+        val curr = mkArticle(billingTopic)
+        ArticleTopic.topicsArticleRemovedFrom(curr, Some(prev)) ==> Seq(deliveryTopic)
+      }
+      test("when there's no previous version") {
+        val curr = mkArticle(billingTopic)
+        ArticleTopic.topicsArticleRemovedFrom(curr, None) ==> Nil
+      }
+    }
+  }
+}

--- a/src/test/scala/managehelpcontentpublisher/PathAndContentTestSuite.scala
+++ b/src/test/scala/managehelpcontentpublisher/PathAndContentTestSuite.scala
@@ -1,21 +1,166 @@
 package managehelpcontentpublisher
 
+import managehelpcontentpublisher.Config.config
 import utest._
 
 /** See [[https://github.com/guardian/salesforce/blob/master/force-app/main/default/classes/ArticleBodyValidation.cls#L5-L20 list of HTML elements we support in Salesforce]].
   */
 object PathAndContentTestSuite extends TestSuite {
 
-  private def publishContents(previousMoreTopics: Option[String]) = PathAndContent.publishContents(
-    { article => Right(PathAndContent(s"testArticles/${article.path}", article.content)) },
-    { topic => Right(PathAndContent(s"testTopics/${topic.path}", topic.content)) },
-    fetchMoreTopics = Right(previousMoreTopics)
-  ) _
+  object Fixtures {
+
+    val article: (String, String) = "how-can-i-redirect-my-delivery" ->
+      """{
+        |  "title": "How can I redirect my delivery?",
+        |  "body": [
+        |    {
+        |      "element": "p",
+        |      "content": [
+        |        {
+        |          "element": "text",
+        |          "content": "Our customer service team will ..."
+        |        }
+        |      ]
+        |    }
+        |  ],
+        |  "path": "how-can-i-redirect-my-delivery",
+        |  "topics": [
+        |    {
+        |      "path": "delivery",
+        |      "title": "Delivery"
+        |    }
+        |  ]
+        |}""".stripMargin
+
+    val deliveryTopic: (String, String) = "delivery" ->
+      """{
+        |  "path": "delivery",
+        |  "title": "Delivery",
+        |  "articles": [
+        |    {
+        |      "path": "can-i-read-your-papermagazines-online",
+        |      "title": "Can I read your paper/magazines online?"
+        |    },
+        |    {
+        |      "path": "how-can-i-redirect-my-delivery",
+        |      "title": "How can I redirect my delivery?"
+        |    },
+        |    {
+        |      "path": "id-like-to-make-a-complaint-about-an-advertisement",
+        |      "title": "I'd like to make a complaint about an advertisement"
+        |    },
+        |    {
+        |      "path": "im-unable-to-comment-and-need-help",
+        |      "title": "I'm unable to comment and need help"
+        |    }
+        |  ]
+        |}""".stripMargin
+
+    val moreTopics: (String, String) = config.topic.moreTopics.path ->
+      """{
+      |  "path": "more-topics",
+      |  "title": "More Topics",
+      |  "topics": [
+      |    {
+      |      "path": "the-guardian-apps",
+      |      "title": "The Guardian apps",
+      |      "articles": [
+      |        {
+      |          "path": "a1",
+      |          "title": "Premium tier access"
+      |        },
+      |        {
+      |          "path": "a2",
+      |          "title": "Apple/Google subscriptions"
+      |        },
+      |        {
+      |          "path": "a3",
+      |          "title": "Personalising your apps"
+      |        }
+      |      ]
+      |    },
+      |    {
+      |      "path": "newsletters-and-emails",
+      |      "title": "Newsletters and emails",
+      |      "articles": [
+      |        {
+      |          "path": "n1",
+      |          "title": "I'm not receiving any emails from you but think I should be"
+      |        },
+      |        {
+      |          "path": "n2",
+      |          "title": "Manage your email preferences"
+      |        }
+      |      ]
+      |    },
+      |    {
+      |      "path": "events",
+      |      "title": "Events",
+      |      "articles": [
+      |        {
+      |          "path": "e1",
+      |          "title":
+      |            "I can no longer attend the live online event, can I have a refund?"
+      |        },
+      |        {
+      |          "path": "e2",
+      |          "title":
+      |            "I can’t find my original confirmation email, can you resend me the event link?"
+      |        },
+      |        {
+      |          "path": "e3",
+      |          "title":
+      |            "Once I have purchased a ticket, how will I attend the online event?"
+      |        },
+      |        {
+      |          "path": "e4",
+      |          "title": "I purchased a book with my ticket, when will I receive this?"
+      |        }
+      |      ]
+      |    },
+      |    {
+      |      "path": "gifting",
+      |      "title": "Gifting",
+      |      "articles": [
+      |        {
+      |          "path": "g1",
+      |          "title": "Gifting a Digital Subscription"
+      |        }
+      |      ]
+      |    },
+      |    {
+      |      "path": "archives",
+      |      "title": "Back issues and archives",
+      |      "articles": [
+      |        {
+      |          "path": "b1",
+      |          "title": "Finding articles from the past in digital format"
+      |        },
+      |        {
+      |          "path": "b2",
+      |          "title": "Old newspapers in physical format"
+      |        }
+      |      ]
+      |    }
+      |  ]
+      |}""".stripMargin
+  }
+
+  private def publishContents(
+      previousArticles: Map[String, String] = Map(),
+      previousTopics: Map[String, String] = Map()
+  ) =
+    PathAndContent.publishContents(
+      fetchArticleByPath = { article => Right(previousArticles.get(article)) },
+      fetchTopicByPath = { topic => Right(previousTopics.get(topic)) },
+      storeArticle = { article => Right(PathAndContent(s"testArticles/${article.path}", article.content)) },
+      storeTopic = { topic => Right(PathAndContent(s"testTopics/${topic.path}", topic.content)) }
+    ) _
 
   val tests: Tests = Tests {
 
     test("Publish when article has a core topic") {
-      val published = publishContents(None)("""{
+      val published = publishContents()("""{
                         |    "dataCategories": [
                         |        {
                         |            "publishedArticles": [
@@ -79,7 +224,7 @@ object PathAndContentTestSuite extends TestSuite {
     }
 
     test("Publish when article has a non-core topic and 'More topics' is empty") {
-      val published = publishContents(None)("""{
+      val published = publishContents()("""{
           |    "dataCategories": [
           |        {
           |            "publishedArticles": [
@@ -151,135 +296,50 @@ object PathAndContentTestSuite extends TestSuite {
     }
 
     test("Publish article, topic and more topics when article has a non-core topic and 'More topics' is not empty") {
-      val previousMoreTopics = """{
-                                 |  "path": "more-topics",
-                                 |  "title": "More Topics",
-                                 |  "topics": [
-                                 |    {
-                                 |      "path": "the-guardian-apps",
-                                 |      "title": "The Guardian apps",
-                                 |      "articles": [
-                                 |        {
-                                 |          "path": "a1",
-                                 |          "title": "Premium tier access"
-                                 |        },
-                                 |        {
-                                 |          "path": "a2",
-                                 |          "title": "Apple/Google subscriptions"
-                                 |        },
-                                 |        {
-                                 |          "path": "a3",
-                                 |          "title": "Personalising your apps"
-                                 |        }
-                                 |      ]
-                                 |    },
-                                 |    {
-                                 |      "path": "newsletters-and-emails",
-                                 |      "title": "Newsletters and emails",
-                                 |      "articles": [
-                                 |        {
-                                 |          "path": "n1",
-                                 |          "title": "I'm not receiving any emails from you but think I should be"
-                                 |        },
-                                 |        {
-                                 |          "path": "n2",
-                                 |          "title": "Manage your email preferences"
-                                 |        }
-                                 |      ]
-                                 |    },
-                                 |    {
-                                 |      "path": "events",
-                                 |      "title": "Events",
-                                 |      "articles": [
-                                 |        {
-                                 |          "path": "e1",
-                                 |          "title":
-                                 |            "I can no longer attend the live online event, can I have a refund?"
-                                 |        },
-                                 |        {
-                                 |          "path": "e2",
-                                 |          "title":
-                                 |            "I can’t find my original confirmation email, can you resend me the event link?"
-                                 |        },
-                                 |        {
-                                 |          "path": "e3",
-                                 |          "title":
-                                 |            "Once I have purchased a ticket, how will I attend the online event?"
-                                 |        },
-                                 |        {
-                                 |          "path": "e4",
-                                 |          "title": "I purchased a book with my ticket, when will I receive this?"
-                                 |        }
-                                 |      ]
-                                 |    },
-                                 |    {
-                                 |      "path": "gifting",
-                                 |      "title": "Gifting",
-                                 |      "articles": [
-                                 |        {
-                                 |          "path": "g1",
-                                 |          "title": "Gifting a Digital Subscription"
-                                 |        }
-                                 |      ]
-                                 |    },
-                                 |    {
-                                 |      "path": "archives",
-                                 |      "title": "Back issues and archives",
-                                 |      "articles": [
-                                 |        {
-                                 |          "path": "b1",
-                                 |          "title": "Finding articles from the past in digital format"
-                                 |        },
-                                 |        {
-                                 |          "path": "b2",
-                                 |          "title": "Old newspapers in physical format"
-                                 |        }
-                                 |      ]
-                                 |    }
-                                 |  ]
-                                 |}""".stripMargin
-      val published = publishContents(Some(previousMoreTopics))("""{
-                                        |    "dataCategories": [
-                                        |        {
-                                        |            "publishedArticles": [
-                                        |                {
-                                        |                    "urlName": "id-like-to-make-a-complaint-about-an-advertisement",
-                                        |                    "title": "I'd like to make a complaint about an advertisement",
-                                        |                    "id": "id1",
-                                        |                    "dataCategories": [],
-                                        |                    "body": null
-                                        |                },
-                                        |                {
-                                        |                    "urlName": "can-i-read-your-papermagazines-online",
-                                        |                    "title": "Can I read your paper/magazines online?",
-                                        |                    "id": "id2",
-                                        |                    "dataCategories": [],
-                                        |                    "body": null
-                                        |                },
-                                        |                {
-                                        |                    "urlName": "im-unable-to-comment-and-need-help",
-                                        |                    "title": "I'm unable to comment and need help",
-                                        |                    "id": "id3",
-                                        |                    "dataCategories": [],
-                                        |                    "body": null
-                                        |                }
-                                        |            ],
-                                        |            "name": "archives__c"
-                                        |        }
-                                        |    ],
-                                        |    "article": {
-                                        |        "urlName": "can-i-read-your-papermagazines-online",
-                                        |        "title": "Can I read your paper/magazines online?",
-                                        |        "id": "id2",
-                                        |        "dataCategories": [
-                                        |            {
-                                        |                "name": "archives__c",
-                                        |                "label": "Back issues and archives"
-                                        |            }
-                                        |        ],
-                                        |        "body": "<p>We do not</p>"
-                                        |    }
-                                        |}""".stripMargin)
+      val published = publishContents(previousTopics = Map(Fixtures.moreTopics))(
+        """{
+        |    "dataCategories": [
+        |        {
+        |            "publishedArticles": [
+        |                {
+        |                    "urlName": "id-like-to-make-a-complaint-about-an-advertisement",
+        |                    "title": "I'd like to make a complaint about an advertisement",
+        |                    "id": "id1",
+        |                    "dataCategories": [],
+        |                    "body": null
+        |                },
+        |                {
+        |                    "urlName": "can-i-read-your-papermagazines-online",
+        |                    "title": "Can I read your paper/magazines online?",
+        |                    "id": "id2",
+        |                    "dataCategories": [],
+        |                    "body": null
+        |                },
+        |                {
+        |                    "urlName": "im-unable-to-comment-and-need-help",
+        |                    "title": "I'm unable to comment and need help",
+        |                    "id": "id3",
+        |                    "dataCategories": [],
+        |                    "body": null
+        |                }
+        |            ],
+        |            "name": "archives__c"
+        |        }
+        |    ],
+        |    "article": {
+        |        "urlName": "can-i-read-your-papermagazines-online",
+        |        "title": "Can I read your paper/magazines online?",
+        |        "id": "id2",
+        |        "dataCategories": [
+        |            {
+        |                "name": "archives__c",
+        |                "label": "Back issues and archives"
+        |            }
+        |        ],
+        |        "body": "<p>We do not</p>"
+        |    }
+        |}""".stripMargin
+      )
       test("number of files published") {
         published.map(_.length) ==> Right(3)
       }
@@ -304,6 +364,83 @@ object PathAndContentTestSuite extends TestSuite {
           PathAndContent(
             "testTopics/more-topics",
             """{"path":"more-topics","title":"More topics","topics":[{"path":"archives","title":"Back issues and archives","articles":[{"path":"can-i-read-your-papermagazines-online","title":"Can I read your paper/magazines online?"},{"path":"id-like-to-make-a-complaint-about-an-advertisement","title":"I'd like to make a complaint about an advertisement"},{"path":"im-unable-to-comment-and-need-help","title":"I'm unable to comment and need help"}]},{"path":"events","title":"Events","articles":[{"path":"e1","title":"I can no longer attend the live online event, can I have a refund?"},{"path":"e2","title":"I can’t find my original confirmation email, can you resend me the event link?"},{"path":"e3","title":"Once I have purchased a ticket, how will I attend the online event?"},{"path":"e4","title":"I purchased a book with my ticket, when will I receive this?"}]},{"path":"gifting","title":"Gifting","articles":[{"path":"g1","title":"Gifting a Digital Subscription"}]},{"path":"newsletters-and-emails","title":"Newsletters and emails","articles":[{"path":"n1","title":"I'm not receiving any emails from you but think I should be"},{"path":"n2","title":"Manage your email preferences"}]},{"path":"the-guardian-apps","title":"The Guardian apps","articles":[{"path":"a1","title":"Premium tier access"},{"path":"a2","title":"Apple/Google subscriptions"},{"path":"a3","title":"Personalising your apps"}]}]}"""
+          )
+        )
+      }
+    }
+
+    test("When topic has changed, publish article and new topic and remove article from old topic") {
+      val published = publishContents(
+        previousArticles = Map(Fixtures.article),
+        previousTopics = Map(Fixtures.deliveryTopic)
+      )(
+        """{
+          |    "dataCategories": [
+          |        {
+          |            "publishedArticles": [
+          |                {
+          |                    "urlName": "id-like-to-make-a-complaint-about-an-advertisement",
+          |                    "title": "I'd like to make a complaint about an advertisement",
+          |                    "id": "id1",
+          |                    "dataCategories": [],
+          |                    "body": null
+          |                },
+          |                {
+          |                    "urlName": "how-can-i-redirect-my-delivery",
+          |                    "title": "How can I redirect my delivery?",
+          |                    "id": "id2",
+          |                    "dataCategories": [],
+          |                    "body": null
+          |                },
+          |                {
+          |                    "urlName": "im-unable-to-comment-and-need-help",
+          |                    "title": "I'm unable to comment and need help",
+          |                    "id": "id3",
+          |                    "dataCategories": [],
+          |                    "body": null
+          |                }
+          |            ],
+          |            "name": "website__c"
+          |        }
+          |    ],
+          |    "article": {
+          |        "urlName": "how-can-i-redirect-my-delivery",
+          |        "title": "How can I redirect my delivery?",
+          |        "id": "id2",
+          |        "dataCategories": [
+          |            {
+          |                "name": "website__c",
+          |                "label": "The Guardian website"
+          |            }
+          |        ],
+          |        "body": "<p>We do not</p>"
+          |    }
+          |}""".stripMargin
+      )
+      test("number of files published") {
+        published.map(_.length) ==> Right(3)
+      }
+      test("article published") {
+        published.map(_(0)) ==> Right(
+          PathAndContent(
+            "testArticles/how-can-i-redirect-my-delivery",
+            """{"title":"How can I redirect my delivery?","body":[{"element":"p","content":[{"element":"text","content":"We do not"}]}],"path":"how-can-i-redirect-my-delivery","topics":[{"path":"website","title":"The Guardian website"}]}"""
+          )
+        )
+      }
+      test("topic published") {
+        published.map(_(1)) ==> Right(
+          PathAndContent(
+            "testTopics/website",
+            """{"path":"website","title":"The Guardian website","articles":[{"path":"how-can-i-redirect-my-delivery","title":"How can I redirect my delivery?"},{"path":"id-like-to-make-a-complaint-about-an-advertisement","title":"I'd like to make a complaint about an advertisement"},{"path":"im-unable-to-comment-and-need-help","title":"I'm unable to comment and need help"}]}"""
+          )
+        )
+      }
+      test("topic republished without article") {
+        published.map(_(2)) ==> Right(
+          PathAndContent(
+            "testTopics/delivery",
+            """{"path":"delivery","title":"Delivery","articles":[{"path":"can-i-read-your-papermagazines-online","title":"Can I read your paper/magazines online?"},{"path":"id-like-to-make-a-complaint-about-an-advertisement","title":"I'd like to make a complaint about an advertisement"},{"path":"im-unable-to-comment-and-need-help","title":"I'm unable to comment and need help"}]}"""
           )
         )
       }


### PR DESCRIPTION
This removes articles from topic pages when necessary.

It does this by:
1. [searching for the previous version of the article](https://github.com/guardian/manage-help-content-publisher/compare/kc-article-change?expand=1#diff-db09425e7d17a397436623627dbbc7263593c7c21d5cc87a63ef7a59b4d5ce31R109), if any,
1. [comparing topics of the new version of the article with the topics of the previous published version](https://github.com/guardian/manage-help-content-publisher/compare/kc-article-change?expand=1#diff-36c0765d203a09eda21d13651ff790fbf66bda6d199e2df673c55be291255d1fR34-R35),
1. [removing the article from the topic it no longer appears in](https://github.com/guardian/manage-help-content-publisher/compare/kc-article-change?expand=1#diff-db09425e7d17a397436623627dbbc7263593c7c21d5cc87a63ef7a59b4d5ce31R114-R117).

Next step is to do the same for the 'More topics' super topic.
