### PR TITLE
Remove redundant articles from 'More topics' page

### DIFF
--- a/src/main/scala/managehelpcontentpublisher/MoreTopics.scala
+++ b/src/main/scala/managehelpcontentpublisher/MoreTopics.scala
@@ -21,14 +21,22 @@ object MoreTopics {
     * Core topics are not included in MoreTopics.
     *
     * @param oldMoreTopics Base for the new MoreTopics if there is a pre-existing instance.
+    * @param articleToRemove An article to remove from all topic lists before adding new topics.
     * @param newTopics New topic lists to add to the base list, replacing any lists with the same paths.
     * @return New instance combining the old instance and the new lists.
     */
-  def withNewTopics(oldMoreTopics: Option[MoreTopics], newTopics: Seq[Topic]): Option[MoreTopics] = {
+  def withNewTopics(
+      oldMoreTopics: Option[MoreTopics],
+      articleToRemove: Option[Article],
+      newTopics: Seq[Topic]
+  ): Option[MoreTopics] = {
+    def removeArticle(topic: Topic): Topic = articleToRemove.fold(topic) { article =>
+      topic.copy(articles = topic.articles.filterNot(_.path == article.path))
+    }
     def toMap(topics: Seq[Topic]) = topics.map(topic => topic.path -> topic).toMap
     val topics = oldMoreTopics
       .fold(newTopics) { moreTopics =>
-        val combinedTopics = toMap(moreTopics.topics) ++ toMap(newTopics)
+        val combinedTopics = toMap(moreTopics.topics.map(removeArticle)) ++ toMap(newTopics)
         combinedTopics.values.toSeq
       }
       .filterNot(topic => config.topic.corePaths.contains(topic.path))

--- a/src/main/scala/managehelpcontentpublisher/PathAndContent.scala
+++ b/src/main/scala/managehelpcontentpublisher/PathAndContent.scala
@@ -95,9 +95,10 @@ object PathAndContent {
       } yield storeTopic(PathAndContent(moreTopics.path, content))
 
       // No need to do anything if the new topics and the topics of the old article are all core topics
+      def isCore(path: String) = config.topic.corePaths.contains(path)
       if (
-        newTopics.forall(topic => config.topic.corePaths.contains(topic.path)) &&
-        oldArticle.forall(_.topics.forall(topic => config.topic.corePaths.contains(topic.path)))
+        newTopics.forall(topic => isCore(topic.path)) &&
+        oldArticle.forall(_.topics.forall(topic => isCore(topic.path)))
       ) Right(None)
       else
         for {

--- a/src/main/scala/managehelpcontentpublisher/PathAndContent.scala
+++ b/src/main/scala/managehelpcontentpublisher/PathAndContent.scala
@@ -76,7 +76,10 @@ object PathAndContent {
     def publishTopics(topics: Seq[Topic]): Either[Failure, Seq[PathAndContent]] =
       seqToEither(topics.map(publishTopic))
 
-    def publishMoreTopics(articleTopics: Seq[Topic]): Either[Failure, Option[PathAndContent]] = {
+    def publishMoreTopics(
+        oldArticle: Option[Article],
+        newTopics: Seq[Topic]
+    ): Either[Failure, Option[PathAndContent]] = {
 
       def readMoreTopics(jsonString: String): Either[Failure, MoreTopics] =
         Try(read[MoreTopics](jsonString)).toEither.left.map(e =>
@@ -91,12 +94,16 @@ object PathAndContent {
         content <- newContent
       } yield storeTopic(PathAndContent(moreTopics.path, content))
 
-      if (articleTopics.forall(topic => config.topic.corePaths.contains(topic.path))) Right(None)
+      // No need to do anything if the new topics and the topics of the old article are all core topics
+      if (
+        newTopics.forall(topic => config.topic.corePaths.contains(topic.path)) &&
+        oldArticle.forall(_.topics.forall(topic => config.topic.corePaths.contains(topic.path)))
+      ) Right(None)
       else
         for {
           jsonString <- fetchTopicByPath(config.topic.moreTopics.path)
           oldMoreTopics <- optionToEither(jsonString.map(readMoreTopics))
-          newMoreTopics = MoreTopics.withNewTopics(oldMoreTopics, articleTopics)
+          newMoreTopics = MoreTopics.withNewTopics(oldMoreTopics, oldArticle, newTopics)
           content <- optionToEither(newMoreTopics.map(writeMoreTopics))
           result <- optionToEither(storeMoreTopics(newMoreTopics, content))
         } yield result
@@ -110,7 +117,7 @@ object PathAndContent {
       publishedArticle <- publishArticle(newArticle)
       topics = Topic.fromInput(input)
       publishedTopics <- publishTopics(topics)
-      publishedMoreTopics <- publishMoreTopics(topics)
+      publishedMoreTopics <- publishMoreTopics(oldArticle, topics)
       topicsArticleRemovedFrom <- removeFromTopics(
         newArticle,
         ArticleTopic.topicsArticleRemovedFrom(newArticle, oldArticle)

--- a/src/test/scala/managehelpcontentpublisher/MoreTopicsTest.scala
+++ b/src/test/scala/managehelpcontentpublisher/MoreTopicsTest.scala
@@ -1,0 +1,81 @@
+package managehelpcontentpublisher
+
+import managehelpcontentpublisher.Config.config
+import utest._
+
+object MoreTopicsTest extends TestSuite {
+  def tests: Tests = Tests {
+
+    test("withNewTopics") {
+
+      test("No new topics and no pre-existing more topics") {
+        MoreTopics.withNewTopics(oldMoreTopics = None, newTopics = Nil, articleToRemove = None) ==> None
+      }
+
+      test("New topic and no pre-existing more topics") {
+        val topic = Topic(path = "p", title = "t", articles = Seq(TopicArticle(path = "ap", title = "at")))
+        MoreTopics.withNewTopics(
+          oldMoreTopics = None,
+          newTopics = Seq(topic),
+          articleToRemove = None
+        ) ==>
+          Some(
+            MoreTopics(path = config.topic.moreTopics.path, title = config.topic.moreTopics.title, topics = Seq(topic))
+          )
+      }
+
+      test("New topic and pre-existing more topics") {
+        val topic1 = Topic(path = "p1", title = "t1", articles = Seq(TopicArticle(path = "a1p", title = "a1t")))
+        val topic2 = Topic(path = "p2", title = "t2", articles = Seq(TopicArticle(path = "a2p", title = "a2t")))
+        MoreTopics.withNewTopics(
+          oldMoreTopics = Some(
+            MoreTopics(
+              path = config.topic.moreTopics.path,
+              title = config.topic.moreTopics.title,
+              topics = Seq(topic1)
+            )
+          ),
+          newTopics = Seq(topic2),
+          articleToRemove = None
+        ) ==>
+          Some(
+            MoreTopics(
+              path = config.topic.moreTopics.path,
+              title = config.topic.moreTopics.title,
+              topics = Seq(topic1, topic2)
+            )
+          )
+      }
+
+      test("New topic and pre-existing more topics and an article to remove") {
+        val topic1 = Topic(path = "p1", title = "t1", articles = Seq(TopicArticle(path = "a1p", title = "a1t")))
+        val topic2 = Topic(path = "p2", title = "t2", articles = Seq(TopicArticle(path = "a2p", title = "a2t")))
+        MoreTopics.withNewTopics(
+          oldMoreTopics = Some(
+            MoreTopics(
+              path = config.topic.moreTopics.path,
+              title = config.topic.moreTopics.title,
+              topics = Seq(topic1)
+            )
+          ),
+          newTopics = Seq(topic2),
+          articleToRemove = Some(
+            Article(
+              title = "a1t",
+              body = ujson.Null,
+              path = "a1p",
+              topics = Seq(ArticleTopic(path = "p1", title = "t1"))
+            )
+          )
+        ) ==>
+          Some(
+            MoreTopics(
+              path = config.topic.moreTopics.path,
+              title = config.topic.moreTopics.title,
+              topics = Seq(topic1.copy(articles = Nil), topic2)
+            )
+          )
+      }
+    }
+  }
+}

--- a/src/test/scala/managehelpcontentpublisher/PathAndContentTestSuite.scala
+++ b/src/test/scala/managehelpcontentpublisher/PathAndContentTestSuite.scala
@@ -9,7 +9,7 @@ object PathAndContentTestSuite extends TestSuite {
 
   object Fixtures {
 
-    val article: (String, String) = "how-can-i-redirect-my-delivery" ->
+    val article1: (String, String) = "how-can-i-redirect-my-delivery" ->
       """{
         |  "title": "How can I redirect my delivery?",
         |  "body": [
@@ -28,6 +28,29 @@ object PathAndContentTestSuite extends TestSuite {
         |    {
         |      "path": "delivery",
         |      "title": "Delivery"
+        |    }
+        |  ]
+        |}""".stripMargin
+
+    val article2: (String, String) = "can-i-read-your-papermagazines-online" ->
+      """{
+        |  "title": "Can I read your paper/magazines online?",
+        |  "body": [
+        |    {
+        |      "element": "p",
+        |      "content": [
+        |        {
+        |          "element": "text",
+        |          "content": "We do not"
+        |        }
+        |      ]
+        |    }
+        |  ],
+        |  "path": "can-i-read-your-papermagazines-online",
+        |  "topics": [
+        |    {
+        |      "path": "apps",
+        |      "title": "The Guardian apps"
         |    }
         |  ]
         |}""".stripMargin
@@ -66,16 +89,20 @@ object PathAndContentTestSuite extends TestSuite {
       |      "title": "The Guardian apps",
       |      "articles": [
       |        {
-      |          "path": "a1",
-      |          "title": "Premium tier access"
-      |        },
-      |        {
       |          "path": "a2",
       |          "title": "Apple/Google subscriptions"
       |        },
       |        {
+      |           "path": "can-i-read-your-papermagazines-online",
+      |           "title": "Can I read your paper/magazines online?"
+      |        },
+      |        {
       |          "path": "a3",
       |          "title": "Personalising your apps"
+      |        },
+      |        {
+      |          "path": "a1",
+      |          "title": "Premium tier access"
       |        }
       |      ]
       |    },
@@ -296,7 +323,10 @@ object PathAndContentTestSuite extends TestSuite {
     }
 
     test("Publish article, topic and more topics when article has a non-core topic and 'More topics' is not empty") {
-      val published = publishContents(previousTopics = Map(Fixtures.moreTopics))(
+      val published = publishContents(
+        previousArticles = Map(Fixtures.article2),
+        previousTopics = Map(Fixtures.moreTopics)
+      )(
         """{
         |    "dataCategories": [
         |        {
@@ -363,7 +393,7 @@ object PathAndContentTestSuite extends TestSuite {
         published.map(_(2)) ==> Right(
           PathAndContent(
             "testTopics/more-topics",
-            """{"path":"more-topics","title":"More topics","topics":[{"path":"archives","title":"Back issues and archives","articles":[{"path":"can-i-read-your-papermagazines-online","title":"Can I read your paper/magazines online?"},{"path":"id-like-to-make-a-complaint-about-an-advertisement","title":"I'd like to make a complaint about an advertisement"},{"path":"im-unable-to-comment-and-need-help","title":"I'm unable to comment and need help"}]},{"path":"events","title":"Events","articles":[{"path":"e1","title":"I can no longer attend the live online event, can I have a refund?"},{"path":"e2","title":"I can’t find my original confirmation email, can you resend me the event link?"},{"path":"e3","title":"Once I have purchased a ticket, how will I attend the online event?"},{"path":"e4","title":"I purchased a book with my ticket, when will I receive this?"}]},{"path":"gifting","title":"Gifting","articles":[{"path":"g1","title":"Gifting a Digital Subscription"}]},{"path":"newsletters-and-emails","title":"Newsletters and emails","articles":[{"path":"n1","title":"I'm not receiving any emails from you but think I should be"},{"path":"n2","title":"Manage your email preferences"}]},{"path":"the-guardian-apps","title":"The Guardian apps","articles":[{"path":"a1","title":"Premium tier access"},{"path":"a2","title":"Apple/Google subscriptions"},{"path":"a3","title":"Personalising your apps"}]}]}"""
+            """{"path":"more-topics","title":"More topics","topics":[{"path":"archives","title":"Back issues and archives","articles":[{"path":"can-i-read-your-papermagazines-online","title":"Can I read your paper/magazines online?"},{"path":"id-like-to-make-a-complaint-about-an-advertisement","title":"I'd like to make a complaint about an advertisement"},{"path":"im-unable-to-comment-and-need-help","title":"I'm unable to comment and need help"}]},{"path":"events","title":"Events","articles":[{"path":"e1","title":"I can no longer attend the live online event, can I have a refund?"},{"path":"e2","title":"I can’t find my original confirmation email, can you resend me the event link?"},{"path":"e3","title":"Once I have purchased a ticket, how will I attend the online event?"},{"path":"e4","title":"I purchased a book with my ticket, when will I receive this?"}]},{"path":"gifting","title":"Gifting","articles":[{"path":"g1","title":"Gifting a Digital Subscription"}]},{"path":"newsletters-and-emails","title":"Newsletters and emails","articles":[{"path":"n1","title":"I'm not receiving any emails from you but think I should be"},{"path":"n2","title":"Manage your email preferences"}]},{"path":"the-guardian-apps","title":"The Guardian apps","articles":[{"path":"a2","title":"Apple/Google subscriptions"},{"path":"a3","title":"Personalising your apps"},{"path":"a1","title":"Premium tier access"}]}]}"""
           )
         )
       }
@@ -371,7 +401,7 @@ object PathAndContentTestSuite extends TestSuite {
 
     test("When topic has changed, publish article and new topic and remove article from old topic") {
       val published = publishContents(
-        previousArticles = Map(Fixtures.article),
+        previousArticles = Map(Fixtures.article1),
         previousTopics = Map(Fixtures.deliveryTopic)
       )(
         """{


### PR DESCRIPTION
When a non-core topic is removed from an article, republish the 'More topics' page without the article.

The key step is, before adding new topics to the 'More topics' page, we [remove the article from the lists it was in previously](https://github.com/guardian/manage-help-content-publisher/compare/kc-no-more-topics?expand=1#diff-1d0bf09b6013ac73a4f0d92c285717b5cb83feb485f23a222f472f1119f89df9R33-R34).