### PR TITLE
Support taking down articles

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,3 +1,6 @@
 version = 2.7.5
 
 maxColumn = 120
+
+optIn.breaksInsideChains = true
+includeNoParensInSelectChains = true

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -112,7 +112,7 @@ Resources:
         ApiEvent:
           Type: Api
           Properties:
-            Path: /
+            Path: /{articlePath}
             Method: DELETE
             RestApiId:
               Ref: ApiGateway

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -33,10 +33,17 @@ Resources:
         Codebase: https://github.com/guardian/manage-help-content-publisher.
       Policies:
         - Statement:
-            - Sid: S3BucketPolicy
+            - Sid: S3BucketListPolicy
               Effect: Allow
               Action:
                 - s3:ListBucket
+              Resource:
+                # It shouldn't be necessary to have a separate list policy but there seems to be a bug in the S3 service somewhere
+                - arn:aws:s3:::manage-help-content*
+        - Statement:
+            - Sid: S3BucketPolicy
+              Effect: Allow
+              Action:
                 - s3:GetObject
                 - s3:PutObject
               Resource:
@@ -75,10 +82,17 @@ Resources:
         Codebase: https://github.com/guardian/manage-help-content-publisher.
       Policies:
         - Statement:
-            - Sid: S3BucketPolicy
+            - Sid: S3BucketListPolicy
               Effect: Allow
               Action:
                 - s3:ListBucket
+              Resource:
+                # It shouldn't be necessary to have a separate list policy but there seems to be a bug in the S3 service somewhere
+                - arn:aws:s3:::manage-help-content*
+        - Statement:
+            - Sid: S3BucketPolicy
+              Effect: Allow
+              Action:
                 - s3:GetObject
                 - s3:PutObject
                 - s3:DeleteObject

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -60,9 +60,15 @@ Resources:
             RestApiId:
               Ref: ApiGateway
 
+  TakingDownLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/lambda/${AppName}-takedown-${Stage}
+      RetentionInDays: 90
+
   TakingDownLambda:
     Type: AWS::Serverless::Function
-    DependsOn: LogGroup
+    DependsOn: TakingDownLogGroup
     Properties:
       FunctionName: !Sub ${AppName}-takedown-${Stage}
       Description: >

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -39,10 +39,9 @@ Resources:
                 - s3:ListBucket
                 - s3:GetObject
                 - s3:PutObject
-                - s3:DeleteObject
               Resource:
                 - !Sub arn:aws:s3:::manage-help-content/${Stage}/*
-      Handler: managehelpcontentpublisher.Handler::handleRequest
+      Handler: managehelpcontentpublisher.PublishingHandler::handleRequest
       Runtime: java11
       CodeUri:
         Bucket: membership-dist
@@ -61,9 +60,48 @@ Resources:
             RestApiId:
               Ref: ApiGateway
 
+  TakingDownLambda:
+    Type: AWS::Serverless::Function
+    DependsOn: LogGroup
+    Properties:
+      FunctionName: !Sub ${AppName}-takedown-${Stage}
+      Description: >
+        Codebase: https://github.com/guardian/manage-help-content-publisher.
+      Policies:
+        - Statement:
+            - Sid: S3BucketPolicy
+              Effect: Allow
+              Action:
+                - s3:ListBucket
+                - s3:GetObject
+                - s3:PutObject
+                - s3:DeleteObject
+              Resource:
+                - !Sub arn:aws:s3:::manage-help-content/${Stage}/*
+      Handler: managehelpcontentpublisher.TakingDownHandler::handleRequest
+      Runtime: java11
+      CodeUri:
+        Bucket: membership-dist
+        Key: !Sub membership/${Stage}/${AppName}/${AppName}.jar
+      Environment:
+        Variables:
+          stage: !Ref Stage
+      Timeout: 30
+      MemorySize: 2048
+      Events:
+        ApiEvent:
+          Type: Api
+          Properties:
+            Path: /
+            Method: DELETE
+            RestApiId:
+              Ref: ApiGateway
+
   ApiGateway:
     Type: AWS::Serverless::Api
-    DependsOn: Lambda
+    DependsOn:
+      - Lambda
+      - TakingDownLambda
     Properties:
       Name: !Sub ${AppName}-${Stage}-api-gateway
       StageName: !Sub ${Stage}

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -20,3 +20,14 @@ deployments:
       prefixStack: false
     dependencies:
       - cfn
+
+  manage-help-content-takedowner:
+    type: aws-lambda
+    parameters:
+      bucket: membership-dist
+      fileName: manage-help-content-publisher.jar
+      functionNames:
+        - manage-help-content-publisher-takedown-
+      prefixStack: false
+    dependencies:
+      - cfn

--- a/src/main/scala/managehelpcontentpublisher/Article.scala
+++ b/src/main/scala/managehelpcontentpublisher/Article.scala
@@ -3,6 +3,8 @@ package managehelpcontentpublisher
 import managehelpcontentpublisher.SalesforceCleaner.cleanCustomFieldName
 import upickle.default._
 
+import scala.util.Try
+
 case class Article(title: String, body: ujson.Value, path: String, topics: Seq[ArticleTopic])
 
 object Article {
@@ -15,6 +17,12 @@ object Article {
     path = input.urlName,
     topics = input.dataCategories.map(ArticleTopic.fromSalesforceDataCategory)
   )
+
+  def readArticle(jsonString: String): Either[Failure, Article] =
+    Try(read[Article](jsonString)).toEither.left.map(e => Failure(s"Failed to read article: ${e.getMessage}"))
+
+  def writeArticle(article: Article): Either[Failure, String] =
+    Try(write(article)).toEither.left.map(e => Failure(s"Failed to write article: ${e.getMessage}"))
 }
 
 case class ArticleTopic(path: String, title: String)

--- a/src/main/scala/managehelpcontentpublisher/Article.scala
+++ b/src/main/scala/managehelpcontentpublisher/Article.scala
@@ -19,10 +19,10 @@ object Article {
   )
 
   def readArticle(jsonString: String): Either[Failure, Article] =
-    Try(read[Article](jsonString)).toEither.left.map(e => Failure(s"Failed to read article: ${e.getMessage}"))
+    Try(read[Article](jsonString)).toEither.left.map(e => ResponseFailure(s"Failed to read article: ${e.getMessage}"))
 
   def writeArticle(article: Article): Either[Failure, String] =
-    Try(write(article)).toEither.left.map(e => Failure(s"Failed to write article: ${e.getMessage}"))
+    Try(write(article)).toEither.left.map(e => ResponseFailure(s"Failed to write article: ${e.getMessage}"))
 }
 
 case class ArticleTopic(path: String, title: String)

--- a/src/main/scala/managehelpcontentpublisher/Eithers.scala
+++ b/src/main/scala/managehelpcontentpublisher/Eithers.scala
@@ -2,15 +2,19 @@ package managehelpcontentpublisher
 
 object Eithers {
 
-  def seqToEither[E, A](eithers: Seq[Either[E, A]]): Either[E, Seq[A]] =
-    eithers.partitionMap(identity) match {
+  // extension method because has same semantics as cats.sequence: https://typelevel.org/cats/typeclasses/traverse.html
+  implicit class SeqToEither[E, A](eithers: Seq[Either[E, A]]) {
+    val sequence: Either[E, Seq[A]] = eithers.partitionMap(identity) match {
       case (firstLeft :: _, _) => Left(firstLeft)
       case (_, as)             => Right(as)
     }
+  }
 
-  def optionToEither[E, A](optEither: Option[Either[E, A]]): Either[E, Option[A]] =
-    optEither match {
+  // extension method because has same semantics as cats.sequence: https://typelevel.org/cats/typeclasses/traverse.html
+  implicit class OptionToEither[E, A](optEither: Option[Either[E, A]]) {
+    val sequence: Either[E, Option[A]] = optEither match {
       case None         => Right(None)
       case Some(either) => either.map(Some(_))
     }
+  }
 }

--- a/src/main/scala/managehelpcontentpublisher/Failure.scala
+++ b/src/main/scala/managehelpcontentpublisher/Failure.scala
@@ -1,3 +1,11 @@
 package managehelpcontentpublisher
 
-case class Failure(reason: String)
+sealed trait Failure { def reason: String }
+
+case object NotFoundFailure extends Failure {
+  val reason: String = "Resource not found"
+}
+
+case class RequestFailure(reason: String) extends Failure
+
+case class ResponseFailure(reason: String) extends Failure

--- a/src/main/scala/managehelpcontentpublisher/Handler.scala
+++ b/src/main/scala/managehelpcontentpublisher/Handler.scala
@@ -1,0 +1,40 @@
+package managehelpcontentpublisher
+
+import com.amazonaws.services.lambda.runtime.Context
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
+import managehelpcontentpublisher.Logging.{logError, logPublished}
+import managehelpcontentpublisher.PublishingHandler.publishContents
+
+import java.io.File
+import scala.io.Source
+
+object Handler {
+
+  def main(process: String => Either[Failure, Seq[PathAndContent]], in: File): Unit = {
+    val src = Source.fromFile(in)
+    val input = src.mkString
+    src.close()
+    process(input) match {
+      case Left(e) => println(s"Failed: ${e.reason}")
+      case Right(published) =>
+        println(s"Success!")
+        published.foreach(item => println(s"Wrote to ${item.path}: ${item.content}"))
+    }
+  }
+
+  def buildResponse(context: Context, result: Either[Failure, Seq[PathAndContent]]): APIGatewayProxyResponseEvent =
+    result match {
+      case Left(RequestFailure(reason)) =>
+        logError(context, reason)
+        new APIGatewayProxyResponseEvent().withStatusCode(400).withBody(reason)
+      case Left(NotFoundFailure) =>
+        logError(context, NotFoundFailure.reason)
+        new APIGatewayProxyResponseEvent().withStatusCode(404).withBody(NotFoundFailure.reason)
+      case Left(ResponseFailure(reason)) =>
+        logError(context, reason)
+        new APIGatewayProxyResponseEvent().withStatusCode(500).withBody(reason)
+      case Right(published) =>
+        published.foreach(logPublished(context))
+        new APIGatewayProxyResponseEvent().withStatusCode(204)
+    }
+}

--- a/src/main/scala/managehelpcontentpublisher/Handler.scala
+++ b/src/main/scala/managehelpcontentpublisher/Handler.scala
@@ -29,7 +29,7 @@ object Handler {
         new APIGatewayProxyResponseEvent().withStatusCode(400).withBody(reason)
       case Left(NotFoundFailure) =>
         logError(context, NotFoundFailure.reason)
-        new APIGatewayProxyResponseEvent().withStatusCode(404).withBody(NotFoundFailure.reason)
+        new APIGatewayProxyResponseEvent().withStatusCode(404)
       case Left(ResponseFailure(reason)) =>
         logError(context, reason)
         new APIGatewayProxyResponseEvent().withStatusCode(500).withBody(reason)

--- a/src/main/scala/managehelpcontentpublisher/InputModel.scala
+++ b/src/main/scala/managehelpcontentpublisher/InputModel.scala
@@ -10,7 +10,7 @@ object InputModel {
   implicit val reader: Reader[InputModel] = macroR
 
   def readInput(jsonString: String): Either[Failure, InputModel] =
-    Try(read[InputModel](jsonString)).toEither.left.map(e => Failure(s"Failed to read input: ${e.getMessage}"))
+    Try(read[InputModel](jsonString)).toEither.left.map(e => RequestFailure(s"Failed to read input: ${e.getMessage}"))
 }
 
 case class InputArticle(

--- a/src/main/scala/managehelpcontentpublisher/InputModel.scala
+++ b/src/main/scala/managehelpcontentpublisher/InputModel.scala
@@ -2,10 +2,15 @@ package managehelpcontentpublisher
 
 import upickle.default._
 
+import scala.util.Try
+
 case class InputModel(article: InputArticle, dataCategories: Seq[DataCategory])
 
 object InputModel {
   implicit val reader: Reader[InputModel] = macroR
+
+  def readInput(jsonString: String): Either[Failure, InputModel] =
+    Try(read[InputModel](jsonString)).toEither.left.map(e => Failure(s"Failed to read input: ${e.getMessage}"))
 }
 
 case class InputArticle(

--- a/src/main/scala/managehelpcontentpublisher/Logging.scala
+++ b/src/main/scala/managehelpcontentpublisher/Logging.scala
@@ -14,8 +14,11 @@ object Logging {
 
   def logError(context: Context, message: String): Unit = log(context, "ERROR", Obj("message" -> message))
 
-  def logRequest(context: Context, request: APIGatewayProxyRequestEvent): Unit =
-    logInfo(context, "Request", Obj("body" -> request.getBody))
+  def logPublishingRequest(context: Context, request: APIGatewayProxyRequestEvent): Unit =
+    logInfo(context, "Publish request", Obj("body" -> request.getBody))
+
+  def logTakingDownRequest(context: Context, request: APIGatewayProxyRequestEvent): Unit =
+    logInfo(context, "Takedown request", Obj("body" -> request.getBody))
 
   def logResponse(context: Context, response: APIGatewayProxyResponseEvent): Unit = {
     logInfo(

--- a/src/main/scala/managehelpcontentpublisher/Logging.scala
+++ b/src/main/scala/managehelpcontentpublisher/Logging.scala
@@ -2,7 +2,7 @@ package managehelpcontentpublisher
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.events.{APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent}
-import ujson.Obj
+import ujson.{Obj, Str}
 
 object Logging {
 
@@ -14,11 +14,8 @@ object Logging {
 
   def logError(context: Context, message: String): Unit = log(context, "ERROR", Obj("message" -> message))
 
-  def logPublishingRequest(context: Context, request: APIGatewayProxyRequestEvent): Unit =
-    logInfo(context, "Publish request", Obj("body" -> request.getBody))
-
-  def logTakingDownRequest(context: Context, request: APIGatewayProxyRequestEvent): Unit =
-    logInfo(context, "Takedown request", Obj("body" -> request.getBody))
+  def logRequest(context: Context, request: APIGatewayProxyRequestEvent): Unit =
+    logInfo(context, "Request", Obj("body" -> Option(request.getBody).map(body => Str(body)).getOrElse(ujson.Null)))
 
   def logResponse(context: Context, response: APIGatewayProxyResponseEvent): Unit = {
     logInfo(

--- a/src/main/scala/managehelpcontentpublisher/MoreTopics.scala
+++ b/src/main/scala/managehelpcontentpublisher/MoreTopics.scala
@@ -48,9 +48,9 @@ object MoreTopics {
 
   def readMoreTopics(jsonString: String): Either[Failure, MoreTopics] =
     Try(read[MoreTopics](jsonString)).toEither.left.map(e =>
-      Failure(s"Failed to read more topics from '$jsonString': ${e.getMessage}")
+      ResponseFailure(s"Failed to read more topics from '$jsonString': ${e.getMessage}")
     )
 
   def writeMoreTopics(moreTopics: MoreTopics): Either[Failure, String] =
-    Try(write(moreTopics)).toEither.left.map(e => Failure(s"Failed to write $moreTopics: ${e.getMessage}"))
+    Try(write(moreTopics)).toEither.left.map(e => ResponseFailure(s"Failed to write $moreTopics: ${e.getMessage}"))
 }

--- a/src/main/scala/managehelpcontentpublisher/MoreTopics.scala
+++ b/src/main/scala/managehelpcontentpublisher/MoreTopics.scala
@@ -3,6 +3,8 @@ package managehelpcontentpublisher
 import managehelpcontentpublisher.Config.config
 import upickle.default._
 
+import scala.util.Try
+
 /** A compilation of published articles by topic in the non-core topics.
   */
 case class MoreTopics(path: String, title: String, topics: Seq[Topic])
@@ -43,4 +45,12 @@ object MoreTopics {
       .sortBy(_.title)
     if (topics.isEmpty) None else Some(MoreTopics(topics))
   }
+
+  def readMoreTopics(jsonString: String): Either[Failure, MoreTopics] =
+    Try(read[MoreTopics](jsonString)).toEither.left.map(e =>
+      Failure(s"Failed to read more topics from '$jsonString': ${e.getMessage}")
+    )
+
+  def writeMoreTopics(moreTopics: MoreTopics): Either[Failure, String] =
+    Try(write(moreTopics)).toEither.left.map(e => Failure(s"Failed to write $moreTopics: ${e.getMessage}"))
 }

--- a/src/main/scala/managehelpcontentpublisher/PathAndContent.scala
+++ b/src/main/scala/managehelpcontentpublisher/PathAndContent.scala
@@ -1,15 +1,58 @@
 package managehelpcontentpublisher
 
-import managehelpcontentpublisher.Article.fromInput
+import managehelpcontentpublisher.Article.{fromInput, readArticle, writeArticle}
 import managehelpcontentpublisher.Config.config
 import managehelpcontentpublisher.Eithers._
-import upickle.default._
-
-import scala.util.Try
+import managehelpcontentpublisher.InputModel.readInput
+import managehelpcontentpublisher.MoreTopics.{readMoreTopics, writeMoreTopics}
+import managehelpcontentpublisher.Topic.{readTopic, writeTopic}
 
 case class PathAndContent(path: String, content: String)
 
 object PathAndContent {
+
+  private def removeFromTopics(
+      fetchTopicByPath: String => Either[Failure, Option[String]],
+      storeTopic: PathAndContent => Either[Failure, PathAndContent]
+  )(article: Article, topics: Seq[ArticleTopic]): Either[Failure, Seq[PathAndContent]] =
+    seqToEither(topics.map(removeFromTopic(fetchTopicByPath, storeTopic)(article))).map(_.flatten)
+
+  private def removeFromTopic(
+      fetchTopicByPath: String => Either[Failure, Option[String]],
+      storeTopic: PathAndContent => Either[Failure, PathAndContent]
+  )(article: Article)(articleTopic: ArticleTopic): Either[Failure, Option[PathAndContent]] =
+    for {
+      oldTopicJson <- fetchTopicByPath(articleTopic.path)
+      oldTopic <- optionToEither(oldTopicJson.map(readTopic))
+      newTopicJson <- optionToEither(oldTopic.map(Topic.removeFromTopic(article)).map(writeTopic))
+      newTopic <- optionToEither(newTopicJson.map(content => storeTopic(PathAndContent(articleTopic.path, content))))
+    } yield newTopic
+
+  private def publishMoreTopics(
+      fetchTopicByPath: String => Either[Failure, Option[String]],
+      storeTopic: PathAndContent => Either[Failure, PathAndContent]
+  )(oldArticle: Option[Article], newTopics: Seq[Topic]): Either[Failure, Option[PathAndContent]] = {
+
+    def storeMoreTopics(prevMoreTopics: Option[MoreTopics], newContent: Option[String]) = for {
+      moreTopics <- prevMoreTopics
+      content <- newContent
+    } yield storeTopic(PathAndContent(moreTopics.path, content))
+
+    // No need to do anything if the new topics and the topics of the old article are all core topics
+    def isCore(path: String) = config.topic.corePaths.contains(path)
+    if (
+      newTopics.forall(topic => isCore(topic.path)) &&
+      oldArticle.forall(_.topics.forall(topic => isCore(topic.path)))
+    ) Right(None)
+    else
+      for {
+        jsonString <- fetchTopicByPath(config.topic.moreTopics.path)
+        oldMoreTopics <- optionToEither(jsonString.map(readMoreTopics))
+        newMoreTopics = MoreTopics.withNewTopics(oldMoreTopics, oldArticle, newTopics)
+        content <- optionToEither(newMoreTopics.map(writeMoreTopics))
+        result <- optionToEither(storeMoreTopics(newMoreTopics, content))
+      } yield result
+  }
 
   /** Publishes the contents of the given Json string
     * to representations of an Article and multiple Topics
@@ -22,7 +65,7 @@ object PathAndContent {
     * @param storeArticle Function that will store the new representation of an Article somewhere.
     * @param storeTopic Function that will store the new representation of a Topic somewhere.
     * @param jsonString A Json string holding all the data needed to publish an Article and its Topics.
-    * @return List of PathAndContents published.
+    * @return List of PathAndContents published.<br />
     *         The meaning of Path depends on the implementation of storeArticle and storeTopic.
     */
   def publishContents(
@@ -32,97 +75,58 @@ object PathAndContent {
       storeTopic: PathAndContent => Either[Failure, PathAndContent]
   )(jsonString: String): Either[Failure, Seq[PathAndContent]] = {
 
-    def readInput(jsonString: String): Either[Failure, InputModel] =
-      Try(read[InputModel](jsonString)).toEither.left.map(e => Failure(s"Failed to read input: ${e.getMessage}"))
-
-    def readArticle(jsonString: String): Either[Failure, Article] =
-      Try(read[Article](jsonString)).toEither.left.map(e => Failure(s"Failed to read article: ${e.getMessage}"))
-
-    def writeTopic(topic: Topic): Either[Failure, String] =
-      Try(write(topic)).toEither.left.map(e => Failure(s"Failed to write topic: ${e.getMessage}"))
-
-    def publishArticle(article: Article): Either[Failure, PathAndContent] = {
-      def writeArticle(article: Article): Either[Failure, String] =
-        Try(write(article)).toEither.left.map(e => Failure(s"Failed to write article: ${e.getMessage}"))
+    def publishArticle(article: Article): Either[Failure, PathAndContent] =
       for {
         content <- writeArticle(article)
         result <- storeArticle(PathAndContent(article.path, content))
       } yield result
-    }
 
-    def publishTopic(topic: Topic): Either[Failure, PathAndContent] = {
+    def publishTopic(topic: Topic): Either[Failure, PathAndContent] =
       for {
         content <- writeTopic(topic)
         result <- storeTopic(PathAndContent(topic.path, content))
       } yield result
-    }
-
-    def removeFromTopics(article: Article, topics: Seq[ArticleTopic]): Either[Failure, Seq[PathAndContent]] =
-      seqToEither(topics.map(removeFromTopic(article))).map(_.flatten)
-
-    def removeFromTopic(article: Article)(articleTopic: ArticleTopic): Either[Failure, Option[PathAndContent]] = {
-
-      def readTopic(jsonString: String): Either[Failure, Topic] =
-        Try(read[Topic](jsonString)).toEither.left.map(e => Failure(s"Failed to read topic: ${e.getMessage}"))
-
-      for {
-        oldTopicJson <- fetchTopicByPath(articleTopic.path)
-        oldTopic <- optionToEither(oldTopicJson.map(readTopic))
-        newTopicJson <- optionToEither(oldTopic.map(Topic.removeFromTopic(article)).map(writeTopic))
-        newTopic <- optionToEither(newTopicJson.map(content => storeTopic(PathAndContent(articleTopic.path, content))))
-      } yield newTopic
-    }
 
     def publishTopics(topics: Seq[Topic]): Either[Failure, Seq[PathAndContent]] =
       seqToEither(topics.map(publishTopic))
 
-    def publishMoreTopics(
-        oldArticle: Option[Article],
-        newTopics: Seq[Topic]
-    ): Either[Failure, Option[PathAndContent]] = {
-
-      def readMoreTopics(jsonString: String): Either[Failure, MoreTopics] =
-        Try(read[MoreTopics](jsonString)).toEither.left.map(e =>
-          Failure(s"Failed to read more topics from '$jsonString': ${e.getMessage}")
-        )
-
-      def writeMoreTopics(moreTopics: MoreTopics): Either[Failure, String] =
-        Try(write(moreTopics)).toEither.left.map(e => Failure(s"Failed to write $moreTopics: ${e.getMessage}"))
-
-      def storeMoreTopics(prevMoreTopics: Option[MoreTopics], newContent: Option[String]) = for {
-        moreTopics <- prevMoreTopics
-        content <- newContent
-      } yield storeTopic(PathAndContent(moreTopics.path, content))
-
-      // No need to do anything if the new topics and the topics of the old article are all core topics
-      def isCore(path: String) = config.topic.corePaths.contains(path)
-      if (
-        newTopics.forall(topic => isCore(topic.path)) &&
-        oldArticle.forall(_.topics.forall(topic => isCore(topic.path)))
-      ) Right(None)
-      else
-        for {
-          jsonString <- fetchTopicByPath(config.topic.moreTopics.path)
-          oldMoreTopics <- optionToEither(jsonString.map(readMoreTopics))
-          newMoreTopics = MoreTopics.withNewTopics(oldMoreTopics, oldArticle, newTopics)
-          content <- optionToEither(newMoreTopics.map(writeMoreTopics))
-          result <- optionToEither(storeMoreTopics(newMoreTopics, content))
-        } yield result
-    }
-
     for {
       input <- readInput(jsonString)
-      newArticle = fromInput(input.article)
+      newArticle = Article.fromInput(input.article)
       oldArticleJson <- fetchArticleByPath(newArticle.path)
       oldArticle <- optionToEither(oldArticleJson.map(readArticle))
       publishedArticle <- publishArticle(newArticle)
       topics = Topic.fromInput(input)
       publishedTopics <- publishTopics(topics)
-      publishedMoreTopics <- publishMoreTopics(oldArticle, topics)
-      topicsArticleRemovedFrom <- removeFromTopics(
+      publishedMoreTopics <- publishMoreTopics(fetchTopicByPath, storeTopic)(oldArticle, topics)
+      topicsArticleRemovedFrom <- removeFromTopics(fetchTopicByPath, storeTopic)(
         newArticle,
         ArticleTopic.topicsArticleRemovedFrom(newArticle, oldArticle)
       )
     } yield Seq(publishedArticle) ++ publishedTopics ++ publishedMoreTopics.toSeq ++ topicsArticleRemovedFrom
   }
+
+  /** Takes down the Article with the given Json representation
+    * and removes it from any published Topics and MoreTopics it belonged to.
+    *
+    * @param deleteArticleByPath Function that will delete the published representation of an Article.
+    * @param fetchTopicByPath Function that fetches the current state of the published topic with the given path
+    *                        or None if there is no such topic.
+    * @param storeTopic Function that will store the new representation of a Topic somewhere.
+    * @param jsonString A Json string holding all the data needed to publish an Article and its Topics.
+    * @return List of PathAndContents modified.<br />
+    *         The meaning of Path depends on the implementation of deleteArticleByPath and storeTopic.
+    */
+  def takeDownArticle(
+      deleteArticleByPath: String => Either[Failure, String],
+      fetchTopicByPath: String => Either[Failure, Option[String]],
+      storeTopic: PathAndContent => Either[Failure, PathAndContent]
+  )(jsonString: String): Either[Failure, Seq[PathAndContent]] =
+    for {
+      input <- readInput(jsonString)
+      article = fromInput(input.article)
+      topicsArticleRemovedFrom <- removeFromTopics(fetchTopicByPath, storeTopic)(article, article.topics)
+      moreTopicsWithoutArticle <- publishMoreTopics(fetchTopicByPath, storeTopic)(Some(article), Nil)
+      deletedPath <- deleteArticleByPath(article.path)
+    } yield topicsArticleRemovedFrom ++ moreTopicsWithoutArticle.toSeq :+ PathAndContent(deletedPath, "")
 }

--- a/src/main/scala/managehelpcontentpublisher/PublishingHandler.scala
+++ b/src/main/scala/managehelpcontentpublisher/PublishingHandler.scala
@@ -7,10 +7,10 @@ import java.io.File
 import scala.io.Source
 import Logging._
 
-object Handler {
+object PublishingHandler {
 
   def handleRequest(request: APIGatewayProxyRequestEvent, context: Context): APIGatewayProxyResponseEvent = {
-    logRequest(context, request)
+    logPublishingRequest(context, request)
     val response = publishContents(request.getBody) match {
       case Left(e) =>
         logError(context, e.reason)

--- a/src/main/scala/managehelpcontentpublisher/PublishingHandler.scala
+++ b/src/main/scala/managehelpcontentpublisher/PublishingHandler.scala
@@ -6,15 +6,14 @@ import managehelpcontentpublisher.Handler.buildResponse
 import managehelpcontentpublisher.Logging._
 
 import java.io.File
+import scala.util.chaining.scalaUtilChainingOps
 
 object PublishingHandler {
 
-  def handleRequest(request: APIGatewayProxyRequestEvent, context: Context): APIGatewayProxyResponseEvent = {
+  def handleRequest(request: APIGatewayProxyRequestEvent, context: Context): APIGatewayProxyResponseEvent =
     logRequest(context, request)
-    val response = buildResponse(context, publishContents(request.getBody))
-    logResponse(context, response)
-    response
-  }
+      .pipe(_ => buildResponse(context, publishContents(request.getBody)))
+      .tap(logResponse(context, _))
 
   def main(args: Array[String]): Unit =
     Handler.main(publishContents, new File(args(0)))

--- a/src/main/scala/managehelpcontentpublisher/PublishingHandler.scala
+++ b/src/main/scala/managehelpcontentpublisher/PublishingHandler.scala
@@ -2,38 +2,22 @@ package managehelpcontentpublisher
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.events.{APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent}
+import managehelpcontentpublisher.Handler.buildResponse
+import managehelpcontentpublisher.Logging._
 
 import java.io.File
-import scala.io.Source
-import Logging._
 
 object PublishingHandler {
 
   def handleRequest(request: APIGatewayProxyRequestEvent, context: Context): APIGatewayProxyResponseEvent = {
     logRequest(context, request)
-    val response = publishContents(request.getBody) match {
-      case Left(e) =>
-        logError(context, e.reason)
-        new APIGatewayProxyResponseEvent().withStatusCode(500).withBody(e.reason)
-      case Right(published) =>
-        published.foreach(logPublished(context))
-        new APIGatewayProxyResponseEvent().withStatusCode(204)
-    }
+    val response = buildResponse(context, publishContents(request.getBody))
     logResponse(context, response)
     response
   }
 
-  def main(args: Array[String]): Unit = {
-    val inFile = Source.fromFile(new File(args(0)))
-    val input = inFile.mkString
-    inFile.close()
-    publishContents(input) match {
-      case Left(e) => println(s"Failed: ${e.reason}")
-      case Right(published) =>
-        println(s"Success!")
-        published.foreach(item => println(s"Wrote to ${item.path}: ${item.content}"))
-    }
-  }
+  def main(args: Array[String]): Unit =
+    Handler.main(publishContents, new File(args(0)))
 
   private def publishContents(jsonString: String): Either[Failure, Seq[PathAndContent]] =
     PathAndContent.publishContents(S3.fetchArticleByPath, S3.fetchTopicByPath, S3.putArticle, S3.putTopic)(jsonString)

--- a/src/main/scala/managehelpcontentpublisher/PublishingHandler.scala
+++ b/src/main/scala/managehelpcontentpublisher/PublishingHandler.scala
@@ -10,7 +10,7 @@ import Logging._
 object PublishingHandler {
 
   def handleRequest(request: APIGatewayProxyRequestEvent, context: Context): APIGatewayProxyResponseEvent = {
-    logPublishingRequest(context, request)
+    logRequest(context, request)
     val response = publishContents(request.getBody) match {
       case Left(e) =>
         logError(context, e.reason)

--- a/src/main/scala/managehelpcontentpublisher/S3.scala
+++ b/src/main/scala/managehelpcontentpublisher/S3.scala
@@ -54,7 +54,8 @@ object S3 {
           .build(),
         RequestBody.fromString(content)
       )
-    ).toEither.left
+    ).toEither
+      .left
       .map(e => ResponseFailure(s"Failed to put $fullPath: ${e.getMessage}"))
       .map(_ => PathAndContent(fullPath, content))
   }
@@ -75,8 +76,8 @@ object S3 {
           .key(key)
           .build()
       )
-    ).toEither.left
-      .map(e => ResponseFailure(s"Failed to delete $fullPath: ${e.getMessage}"))
+    ).toEither
+      .left.map(e => ResponseFailure(s"Failed to delete $fullPath: ${e.getMessage}"))
       .map(_ => fullPath)
   }
 

--- a/src/main/scala/managehelpcontentpublisher/S3.scala
+++ b/src/main/scala/managehelpcontentpublisher/S3.scala
@@ -33,7 +33,7 @@ object S3 {
       .left
       .flatMap {
         case _: NoSuchKeyException => Right(None)
-        case e                     => Left(Failure(s"Failed to get s3://${config.aws.bucketName}/$key: ${e.getMessage}"))
+        case e                     => Left(ResponseFailure(s"Failed to get s3://${config.aws.bucketName}/$key: ${e.getMessage}"))
       }
 
   def fetchArticleByPath(path: String): Either[Failure, Option[String]] =
@@ -55,7 +55,7 @@ object S3 {
         RequestBody.fromString(content)
       )
     ).toEither.left
-      .map(e => Failure(s"Failed to put $fullPath: ${e.getMessage}"))
+      .map(e => ResponseFailure(s"Failed to put $fullPath: ${e.getMessage}"))
       .map(_ => PathAndContent(fullPath, content))
   }
 
@@ -76,7 +76,7 @@ object S3 {
           .build()
       )
     ).toEither.left
-      .map(e => Failure(s"Failed to delete $fullPath: ${e.getMessage}"))
+      .map(e => ResponseFailure(s"Failed to delete $fullPath: ${e.getMessage}"))
       .map(_ => fullPath)
   }
 

--- a/src/main/scala/managehelpcontentpublisher/TakingDownHandler.scala
+++ b/src/main/scala/managehelpcontentpublisher/TakingDownHandler.scala
@@ -6,15 +6,14 @@ import managehelpcontentpublisher.Handler.buildResponse
 import managehelpcontentpublisher.Logging._
 
 import java.io.File
+import scala.util.chaining.scalaUtilChainingOps
 
 object TakingDownHandler {
 
-  def handleRequest(request: APIGatewayProxyRequestEvent, context: Context): APIGatewayProxyResponseEvent = {
+  def handleRequest(request: APIGatewayProxyRequestEvent, context: Context): APIGatewayProxyResponseEvent =
     logRequest(context, request)
-    val response = buildResponse(context, takeDownArticle(request.getPathParameters.get("articlePath")))
-    logResponse(context, response)
-    response
-  }
+      .pipe(_ => buildResponse(context, takeDownArticle(request.getPathParameters.get("articlePath"))))
+      .tap(logResponse(context, _))
 
   def main(args: Array[String]): Unit =
     Handler.main(takeDownArticle, new File(args(0)))

--- a/src/main/scala/managehelpcontentpublisher/TakingDownHandler.scala
+++ b/src/main/scala/managehelpcontentpublisher/TakingDownHandler.scala
@@ -1,0 +1,40 @@
+package managehelpcontentpublisher
+
+import com.amazonaws.services.lambda.runtime.Context
+import com.amazonaws.services.lambda.runtime.events.{APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent}
+import managehelpcontentpublisher.Logging._
+
+import java.io.File
+import scala.io.Source
+
+object TakingDownHandler {
+
+  def handleRequest(request: APIGatewayProxyRequestEvent, context: Context): APIGatewayProxyResponseEvent = {
+    logTakingDownRequest(context, request)
+    val response = takeDownArticle(request.getBody) match {
+      case Left(e) =>
+        logError(context, e.reason)
+        new APIGatewayProxyResponseEvent().withStatusCode(500).withBody(e.reason)
+      case Right(published) =>
+        published.foreach(logPublished(context))
+        new APIGatewayProxyResponseEvent().withStatusCode(204)
+    }
+    logResponse(context, response)
+    response
+  }
+
+  def main(args: Array[String]): Unit = {
+    val inFile = Source.fromFile(new File(args(0)))
+    val input = inFile.mkString
+    inFile.close()
+    takeDownArticle(input) match {
+      case Left(e) => println(s"Failed: ${e.reason}")
+      case Right(modified) =>
+        println(s"Success!")
+        modified.foreach(item => println(s"Wrote to ${item.path}: ${item.content}"))
+    }
+  }
+
+  private def takeDownArticle(jsonString: String): Either[Failure, Seq[PathAndContent]] =
+    PathAndContent.takeDownArticle(S3.deleteArticleByPath, S3.fetchTopicByPath, S3.putTopic)(jsonString)
+}

--- a/src/main/scala/managehelpcontentpublisher/TakingDownHandler.scala
+++ b/src/main/scala/managehelpcontentpublisher/TakingDownHandler.scala
@@ -10,7 +10,7 @@ import scala.io.Source
 object TakingDownHandler {
 
   def handleRequest(request: APIGatewayProxyRequestEvent, context: Context): APIGatewayProxyResponseEvent = {
-    logTakingDownRequest(context, request)
+    logRequest(context, request)
     val response = takeDownArticle(request.getBody) match {
       case Left(e) =>
         logError(context, e.reason)

--- a/src/main/scala/managehelpcontentpublisher/TakingDownHandler.scala
+++ b/src/main/scala/managehelpcontentpublisher/TakingDownHandler.scala
@@ -2,39 +2,25 @@ package managehelpcontentpublisher
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.events.{APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent}
+import managehelpcontentpublisher.Handler.buildResponse
 import managehelpcontentpublisher.Logging._
 
 import java.io.File
-import scala.io.Source
 
 object TakingDownHandler {
 
   def handleRequest(request: APIGatewayProxyRequestEvent, context: Context): APIGatewayProxyResponseEvent = {
     logRequest(context, request)
-    val response = takeDownArticle(request.getBody) match {
-      case Left(e) =>
-        logError(context, e.reason)
-        new APIGatewayProxyResponseEvent().withStatusCode(500).withBody(e.reason)
-      case Right(published) =>
-        published.foreach(logPublished(context))
-        new APIGatewayProxyResponseEvent().withStatusCode(204)
-    }
+    val response = buildResponse(context, takeDownArticle(request.getPathParameters.get("articlePath")))
     logResponse(context, response)
     response
   }
 
-  def main(args: Array[String]): Unit = {
-    val inFile = Source.fromFile(new File(args(0)))
-    val input = inFile.mkString
-    inFile.close()
-    takeDownArticle(input) match {
-      case Left(e) => println(s"Failed: ${e.reason}")
-      case Right(modified) =>
-        println(s"Success!")
-        modified.foreach(item => println(s"Wrote to ${item.path}: ${item.content}"))
-    }
-  }
+  def main(args: Array[String]): Unit =
+    Handler.main(takeDownArticle, new File(args(0)))
 
-  private def takeDownArticle(jsonString: String): Either[Failure, Seq[PathAndContent]] =
-    PathAndContent.takeDownArticle(S3.deleteArticleByPath, S3.fetchTopicByPath, S3.putTopic)(jsonString)
+  private def takeDownArticle(path: String): Either[Failure, Seq[PathAndContent]] =
+    PathAndContent.takeDownArticle(S3.fetchArticleByPath, S3.deleteArticleByPath, S3.fetchTopicByPath, S3.putTopic)(
+      path
+    )
 }

--- a/src/main/scala/managehelpcontentpublisher/Topic.scala
+++ b/src/main/scala/managehelpcontentpublisher/Topic.scala
@@ -3,6 +3,8 @@ package managehelpcontentpublisher
 import managehelpcontentpublisher.SalesforceCleaner.cleanCustomFieldName
 import upickle.default._
 
+import scala.util.Try
+
 case class Topic(path: String, title: String, articles: Seq[TopicArticle])
 
 object Topic {
@@ -18,6 +20,12 @@ object Topic {
       )
     )
   }
+
+  def readTopic(jsonString: String): Either[Failure, Topic] =
+    Try(read[Topic](jsonString)).toEither.left.map(e => Failure(s"Failed to read topic: ${e.getMessage}"))
+
+  def writeTopic(topic: Topic): Either[Failure, String] =
+    Try(write(topic)).toEither.left.map(e => Failure(s"Failed to write topic: ${e.getMessage}"))
 
   def removeFromTopic(article: Article)(topic: Topic): Topic =
     topic.copy(articles = topic.articles.filterNot(_.path == article.path))

--- a/src/main/scala/managehelpcontentpublisher/Topic.scala
+++ b/src/main/scala/managehelpcontentpublisher/Topic.scala
@@ -22,10 +22,10 @@ object Topic {
   }
 
   def readTopic(jsonString: String): Either[Failure, Topic] =
-    Try(read[Topic](jsonString)).toEither.left.map(e => Failure(s"Failed to read topic: ${e.getMessage}"))
+    Try(read[Topic](jsonString)).toEither.left.map(e => ResponseFailure(s"Failed to read topic: ${e.getMessage}"))
 
   def writeTopic(topic: Topic): Either[Failure, String] =
-    Try(write(topic)).toEither.left.map(e => Failure(s"Failed to write topic: ${e.getMessage}"))
+    Try(write(topic)).toEither.left.map(e => ResponseFailure(s"Failed to write topic: ${e.getMessage}"))
 
   def removeFromTopic(article: Article)(topic: Topic): Topic =
     topic.copy(articles = topic.articles.filterNot(_.path == article.path))

--- a/src/test/scala/managehelpcontentpublisher/MoreTopicsTest.scala
+++ b/src/test/scala/managehelpcontentpublisher/MoreTopicsTest.scala
@@ -76,6 +76,35 @@ object MoreTopicsTest extends TestSuite {
             )
           )
       }
+
+      test("Pre-existing more topics and an article to remove") {
+        val topic1 = Topic(path = "p1", title = "t1", articles = Seq(TopicArticle(path = "a1p", title = "a1t")))
+        MoreTopics.withNewTopics(
+          oldMoreTopics = Some(
+            MoreTopics(
+              path = config.topic.moreTopics.path,
+              title = config.topic.moreTopics.title,
+              topics = Seq(topic1)
+            )
+          ),
+          newTopics = Nil,
+          articleToRemove = Some(
+            Article(
+              title = "a1t",
+              body = ujson.Null,
+              path = "a1p",
+              topics = Seq(ArticleTopic(path = "p1", title = "t1"))
+            )
+          )
+        ) ==>
+          Some(
+            MoreTopics(
+              path = config.topic.moreTopics.path,
+              title = config.topic.moreTopics.title,
+              topics = Seq(topic1.copy(articles = Nil))
+            )
+          )
+      }
     }
   }
 }

--- a/src/test/scala/managehelpcontentpublisher/PathAndContentTestSuite.scala
+++ b/src/test/scala/managehelpcontentpublisher/PathAndContentTestSuite.scala
@@ -79,6 +79,30 @@ object PathAndContentTestSuite extends TestSuite {
         |  ]
         |}""".stripMargin
 
+    val appsTopic: (String, String) = "apps" ->
+      """{
+        |  "path": "apps",
+        |  "title": "The Guardian apps",
+        |  "articles": [
+        |    {
+        |      "path": "can-i-read-your-papermagazines-online",
+        |      "title": "Can I read your paper/magazines online?"
+        |    },
+        |    {
+        |      "path": "how-can-i-redirect-my-delivery",
+        |      "title": "How can I redirect my delivery?"
+        |    },
+        |    {
+        |      "path": "id-like-to-make-a-complaint-about-an-advertisement",
+        |      "title": "I'd like to make a complaint about an advertisement"
+        |    },
+        |    {
+        |      "path": "im-unable-to-comment-and-need-help",
+        |      "title": "I'm unable to comment and need help"
+        |    }
+        |  ]
+        |}""".stripMargin
+
     val moreTopics: (String, String) = config.topic.moreTopics.path ->
       """{
       |  "path": "more-topics",
@@ -178,301 +202,379 @@ object PathAndContentTestSuite extends TestSuite {
       previousTopics: Map[String, String] = Map()
   ) =
     PathAndContent.publishContents(
-      fetchArticleByPath = { article => Right(previousArticles.get(article)) },
-      fetchTopicByPath = { topic => Right(previousTopics.get(topic)) },
+      fetchArticleByPath = { path => Right(previousArticles.get(path)) },
+      fetchTopicByPath = { path => Right(previousTopics.get(path)) },
       storeArticle = { article => Right(PathAndContent(s"testArticles/${article.path}", article.content)) },
+      storeTopic = { topic => Right(PathAndContent(s"testTopics/${topic.path}", topic.content)) }
+    ) _
+
+  private def takeDownArticle(
+      topics: Map[String, String] = Map(Fixtures.deliveryTopic, Fixtures.appsTopic, Fixtures.moreTopics)
+  ) =
+    PathAndContent.takeDownArticle(
+      deleteArticleByPath = { path => Right(s"testArticles/$path") },
+      fetchTopicByPath = { path => Right(topics.get(path)) },
       storeTopic = { topic => Right(PathAndContent(s"testTopics/${topic.path}", topic.content)) }
     ) _
 
   val tests: Tests = Tests {
 
-    test("Publish when article has a core topic") {
-      val published = publishContents()("""{
-                        |    "dataCategories": [
-                        |        {
-                        |            "publishedArticles": [
-                        |                {
-                        |                    "urlName": "id-like-to-make-a-complaint-about-an-advertisement",
-                        |                    "title": "I'd like to make a complaint about an advertisement",
-                        |                    "id": "id1",
-                        |                    "dataCategories": [],
-                        |                    "body": null
-                        |                },
-                        |                {
-                        |                    "urlName": "can-i-read-your-papermagazines-online",
-                        |                    "title": "Can I read your paper/magazines online?",
-                        |                    "id": "id2",
-                        |                    "dataCategories": [],
-                        |                    "body": null
-                        |                },
-                        |                {
-                        |                    "urlName": "im-unable-to-comment-and-need-help",
-                        |                    "title": "I'm unable to comment and need help",
-                        |                    "id": "id3",
-                        |                    "dataCategories": [],
-                        |                    "body": null
-                        |                }
-                        |            ],
-                        |            "name": "website__c"
-                        |        }
-                        |    ],
-                        |    "article": {
-                        |        "urlName": "can-i-read-your-papermagazines-online",
-                        |        "title": "Can I read your paper/magazines online?",
-                        |        "id": "id2",
-                        |        "dataCategories": [
-                        |            {
-                        |                "name": "website__c",
-                        |                "label": "The Guardian website"
-                        |            }
-                        |        ],
-                        |        "body": "<p>We do not</p>"
-                        |    }
-                        |}""".stripMargin)
-      test("number of files published") {
-        published.map(_.length) ==> Right(2)
-      }
-      test("article published") {
-        published.map(_(0)) ==> Right(
-          PathAndContent(
-            "testArticles/can-i-read-your-papermagazines-online",
-            """{"title":"Can I read your paper/magazines online?","body":[{"element":"p","content":[{"element":"text","content":"We do not"}]}],"path":"can-i-read-your-papermagazines-online","topics":[{"path":"website","title":"The Guardian website"}]}"""
+    test("publishContents") {
+      test("When article has a core topic") {
+        val published = publishContents()("""{
+            |    "dataCategories": [
+            |        {
+            |            "publishedArticles": [
+            |                {
+            |                    "urlName": "id-like-to-make-a-complaint-about-an-advertisement",
+            |                    "title": "I'd like to make a complaint about an advertisement",
+            |                    "id": "id1",
+            |                    "dataCategories": [],
+            |                    "body": null
+            |                },
+            |                {
+            |                    "urlName": "can-i-read-your-papermagazines-online",
+            |                    "title": "Can I read your paper/magazines online?",
+            |                    "id": "id2",
+            |                    "dataCategories": [],
+            |                    "body": null
+            |                },
+            |                {
+            |                    "urlName": "im-unable-to-comment-and-need-help",
+            |                    "title": "I'm unable to comment and need help",
+            |                    "id": "id3",
+            |                    "dataCategories": [],
+            |                    "body": null
+            |                }
+            |            ],
+            |            "name": "website__c"
+            |        }
+            |    ],
+            |    "article": {
+            |        "urlName": "can-i-read-your-papermagazines-online",
+            |        "title": "Can I read your paper/magazines online?",
+            |        "id": "id2",
+            |        "dataCategories": [
+            |            {
+            |                "name": "website__c",
+            |                "label": "The Guardian website"
+            |            }
+            |        ],
+            |        "body": "<p>We do not</p>"
+            |    }
+            |}""".stripMargin)
+        test("number of files published") {
+          published.map(_.length) ==> Right(2)
+        }
+        test("article published") {
+          published.map(_(0)) ==> Right(
+            PathAndContent(
+              "testArticles/can-i-read-your-papermagazines-online",
+              """{"title":"Can I read your paper/magazines online?","body":[{"element":"p","content":[{"element":"text","content":"We do not"}]}],"path":"can-i-read-your-papermagazines-online","topics":[{"path":"website","title":"The Guardian website"}]}"""
+            )
           )
-        )
-      }
-      test("topic published") {
-        published.map(_(1)) ==> Right(
-          PathAndContent(
-            "testTopics/website",
-            """{"path":"website","title":"The Guardian website","articles":[{"path":"can-i-read-your-papermagazines-online","title":"Can I read your paper/magazines online?"},{"path":"id-like-to-make-a-complaint-about-an-advertisement","title":"I'd like to make a complaint about an advertisement"},{"path":"im-unable-to-comment-and-need-help","title":"I'm unable to comment and need help"}]}"""
+        }
+        test("topic published") {
+          published.map(_(1)) ==> Right(
+            PathAndContent(
+              "testTopics/website",
+              """{"path":"website","title":"The Guardian website","articles":[{"path":"can-i-read-your-papermagazines-online","title":"Can I read your paper/magazines online?"},{"path":"id-like-to-make-a-complaint-about-an-advertisement","title":"I'd like to make a complaint about an advertisement"},{"path":"im-unable-to-comment-and-need-help","title":"I'm unable to comment and need help"}]}"""
+            )
           )
+        }
+      }
+
+      test("When article has a non-core topic and 'More topics' is empty") {
+        val published = publishContents()("""{
+            |    "dataCategories": [
+            |        {
+            |            "publishedArticles": [
+            |                {
+            |                    "urlName": "id-like-to-make-a-complaint-about-an-advertisement",
+            |                    "title": "I'd like to make a complaint about an advertisement",
+            |                    "id": "id1",
+            |                    "dataCategories": [],
+            |                    "body": null
+            |                },
+            |                {
+            |                    "urlName": "can-i-read-your-papermagazines-online",
+            |                    "title": "Can I read your paper/magazines online?",
+            |                    "id": "id2",
+            |                    "dataCategories": [],
+            |                    "body": null
+            |                },
+            |                {
+            |                    "urlName": "im-unable-to-comment-and-need-help",
+            |                    "title": "I'm unable to comment and need help",
+            |                    "id": "id3",
+            |                    "dataCategories": [],
+            |                    "body": null
+            |                }
+            |            ],
+            |            "name": "archives__c"
+            |        }
+            |    ],
+            |    "article": {
+            |        "urlName": "can-i-read-your-papermagazines-online",
+            |        "title": "Can I read your paper/magazines online?",
+            |        "id": "id2",
+            |        "dataCategories": [
+            |            {
+            |                "name": "archives__c",
+            |                "label": "Back issues and archives"
+            |            }
+            |        ],
+            |        "body": "<p>We do not</p>"
+            |    }
+            |}""".stripMargin)
+        test("number of files published") {
+          published.map(_.length) ==> Right(3)
+        }
+        test("article published") {
+          published.map(_(0)) ==> Right(
+            PathAndContent(
+              "testArticles/can-i-read-your-papermagazines-online",
+              """{"title":"Can I read your paper/magazines online?","body":[{"element":"p","content":[{"element":"text","content":"We do not"}]}],"path":"can-i-read-your-papermagazines-online","topics":[{"path":"archives","title":"Back issues and archives"}]}"""
+            )
+          )
+        }
+        test("topic published") {
+          published.map(_(1)) ==> Right(
+            PathAndContent(
+              "testTopics/archives",
+              """{"path":"archives","title":"Back issues and archives","articles":[{"path":"can-i-read-your-papermagazines-online","title":"Can I read your paper/magazines online?"},{"path":"id-like-to-make-a-complaint-about-an-advertisement","title":"I'd like to make a complaint about an advertisement"},{"path":"im-unable-to-comment-and-need-help","title":"I'm unable to comment and need help"}]}"""
+            )
+          )
+        }
+        test("More topics published") {
+          published.map(_(2)) ==> Right(
+            PathAndContent(
+              "testTopics/more-topics",
+              """{"path":"more-topics","title":"More topics","topics":[{"path":"archives","title":"Back issues and archives","articles":[{"path":"can-i-read-your-papermagazines-online","title":"Can I read your paper/magazines online?"},{"path":"id-like-to-make-a-complaint-about-an-advertisement","title":"I'd like to make a complaint about an advertisement"},{"path":"im-unable-to-comment-and-need-help","title":"I'm unable to comment and need help"}]}]}"""
+            )
+          )
+        }
+      }
+
+      test("Article, topic and more topics when article has a non-core topic and 'More topics' is not empty") {
+        val published = publishContents(
+          previousArticles = Map(Fixtures.article2),
+          previousTopics = Map(Fixtures.moreTopics)
+        )(
+          """{
+            |    "dataCategories": [
+            |        {
+            |            "publishedArticles": [
+            |                {
+            |                    "urlName": "id-like-to-make-a-complaint-about-an-advertisement",
+            |                    "title": "I'd like to make a complaint about an advertisement",
+            |                    "id": "id1",
+            |                    "dataCategories": [],
+            |                    "body": null
+            |                },
+            |                {
+            |                    "urlName": "can-i-read-your-papermagazines-online",
+            |                    "title": "Can I read your paper/magazines online?",
+            |                    "id": "id2",
+            |                    "dataCategories": [],
+            |                    "body": null
+            |                },
+            |                {
+            |                    "urlName": "im-unable-to-comment-and-need-help",
+            |                    "title": "I'm unable to comment and need help",
+            |                    "id": "id3",
+            |                    "dataCategories": [],
+            |                    "body": null
+            |                }
+            |            ],
+            |            "name": "archives__c"
+            |        }
+            |    ],
+            |    "article": {
+            |        "urlName": "can-i-read-your-papermagazines-online",
+            |        "title": "Can I read your paper/magazines online?",
+            |        "id": "id2",
+            |        "dataCategories": [
+            |            {
+            |                "name": "archives__c",
+            |                "label": "Back issues and archives"
+            |            }
+            |        ],
+            |        "body": "<p>We do not</p>"
+            |    }
+            |}""".stripMargin
         )
+        test("number of files published") {
+          published.map(_.length) ==> Right(3)
+        }
+        test("article published") {
+          published.map(_(0)) ==> Right(
+            PathAndContent(
+              "testArticles/can-i-read-your-papermagazines-online",
+              """{"title":"Can I read your paper/magazines online?","body":[{"element":"p","content":[{"element":"text","content":"We do not"}]}],"path":"can-i-read-your-papermagazines-online","topics":[{"path":"archives","title":"Back issues and archives"}]}"""
+            )
+          )
+        }
+        test("topic published") {
+          published.map(_(1)) ==> Right(
+            PathAndContent(
+              "testTopics/archives",
+              """{"path":"archives","title":"Back issues and archives","articles":[{"path":"can-i-read-your-papermagazines-online","title":"Can I read your paper/magazines online?"},{"path":"id-like-to-make-a-complaint-about-an-advertisement","title":"I'd like to make a complaint about an advertisement"},{"path":"im-unable-to-comment-and-need-help","title":"I'm unable to comment and need help"}]}"""
+            )
+          )
+        }
+        test("More topics published") {
+          published.map(_(2)) ==> Right(
+            PathAndContent(
+              "testTopics/more-topics",
+              """{"path":"more-topics","title":"More topics","topics":[{"path":"archives","title":"Back issues and archives","articles":[{"path":"can-i-read-your-papermagazines-online","title":"Can I read your paper/magazines online?"},{"path":"id-like-to-make-a-complaint-about-an-advertisement","title":"I'd like to make a complaint about an advertisement"},{"path":"im-unable-to-comment-and-need-help","title":"I'm unable to comment and need help"}]},{"path":"events","title":"Events","articles":[{"path":"e1","title":"I can no longer attend the live online event, can I have a refund?"},{"path":"e2","title":"I can’t find my original confirmation email, can you resend me the event link?"},{"path":"e3","title":"Once I have purchased a ticket, how will I attend the online event?"},{"path":"e4","title":"I purchased a book with my ticket, when will I receive this?"}]},{"path":"gifting","title":"Gifting","articles":[{"path":"g1","title":"Gifting a Digital Subscription"}]},{"path":"newsletters-and-emails","title":"Newsletters and emails","articles":[{"path":"n1","title":"I'm not receiving any emails from you but think I should be"},{"path":"n2","title":"Manage your email preferences"}]},{"path":"the-guardian-apps","title":"The Guardian apps","articles":[{"path":"a2","title":"Apple/Google subscriptions"},{"path":"a3","title":"Personalising your apps"},{"path":"a1","title":"Premium tier access"}]}]}"""
+            )
+          )
+        }
+      }
+
+      test("When topic has changed, publish article and new topic and remove article from old topic") {
+        val published = publishContents(
+          previousArticles = Map(Fixtures.article1),
+          previousTopics = Map(Fixtures.deliveryTopic)
+        )(
+          """{
+            |    "dataCategories": [
+            |        {
+            |            "publishedArticles": [
+            |                {
+            |                    "urlName": "id-like-to-make-a-complaint-about-an-advertisement",
+            |                    "title": "I'd like to make a complaint about an advertisement",
+            |                    "id": "id1",
+            |                    "dataCategories": [],
+            |                    "body": null
+            |                },
+            |                {
+            |                    "urlName": "how-can-i-redirect-my-delivery",
+            |                    "title": "How can I redirect my delivery?",
+            |                    "id": "id2",
+            |                    "dataCategories": [],
+            |                    "body": null
+            |                },
+            |                {
+            |                    "urlName": "im-unable-to-comment-and-need-help",
+            |                    "title": "I'm unable to comment and need help",
+            |                    "id": "id3",
+            |                    "dataCategories": [],
+            |                    "body": null
+            |                }
+            |            ],
+            |            "name": "website__c"
+            |        }
+            |    ],
+            |    "article": {
+            |        "urlName": "how-can-i-redirect-my-delivery",
+            |        "title": "How can I redirect my delivery?",
+            |        "id": "id2",
+            |        "dataCategories": [
+            |            {
+            |                "name": "website__c",
+            |                "label": "The Guardian website"
+            |            }
+            |        ],
+            |        "body": "<p>We do not</p>"
+            |    }
+            |}""".stripMargin
+        )
+        test("number of files published") {
+          published.map(_.length) ==> Right(3)
+        }
+        test("article published") {
+          published.map(_(0)) ==> Right(
+            PathAndContent(
+              "testArticles/how-can-i-redirect-my-delivery",
+              """{"title":"How can I redirect my delivery?","body":[{"element":"p","content":[{"element":"text","content":"We do not"}]}],"path":"how-can-i-redirect-my-delivery","topics":[{"path":"website","title":"The Guardian website"}]}"""
+            )
+          )
+        }
+        test("topic published") {
+          published.map(_(1)) ==> Right(
+            PathAndContent(
+              "testTopics/website",
+              """{"path":"website","title":"The Guardian website","articles":[{"path":"how-can-i-redirect-my-delivery","title":"How can I redirect my delivery?"},{"path":"id-like-to-make-a-complaint-about-an-advertisement","title":"I'd like to make a complaint about an advertisement"},{"path":"im-unable-to-comment-and-need-help","title":"I'm unable to comment and need help"}]}"""
+            )
+          )
+        }
+        test("topic republished without article") {
+          published.map(_(2)) ==> Right(
+            PathAndContent(
+              "testTopics/delivery",
+              """{"path":"delivery","title":"Delivery","articles":[{"path":"can-i-read-your-papermagazines-online","title":"Can I read your paper/magazines online?"},{"path":"id-like-to-make-a-complaint-about-an-advertisement","title":"I'd like to make a complaint about an advertisement"},{"path":"im-unable-to-comment-and-need-help","title":"I'm unable to comment and need help"}]}"""
+            )
+          )
+        }
       }
     }
 
-    test("Publish when article has a non-core topic and 'More topics' is empty") {
-      val published = publishContents()("""{
-          |    "dataCategories": [
-          |        {
-          |            "publishedArticles": [
-          |                {
-          |                    "urlName": "id-like-to-make-a-complaint-about-an-advertisement",
-          |                    "title": "I'd like to make a complaint about an advertisement",
-          |                    "id": "id1",
-          |                    "dataCategories": [],
-          |                    "body": null
-          |                },
-          |                {
-          |                    "urlName": "can-i-read-your-papermagazines-online",
-          |                    "title": "Can I read your paper/magazines online?",
-          |                    "id": "id2",
-          |                    "dataCategories": [],
-          |                    "body": null
-          |                },
-          |                {
-          |                    "urlName": "im-unable-to-comment-and-need-help",
-          |                    "title": "I'm unable to comment and need help",
-          |                    "id": "id3",
-          |                    "dataCategories": [],
-          |                    "body": null
-          |                }
-          |            ],
-          |            "name": "archives__c"
-          |        }
-          |    ],
-          |    "article": {
-          |        "urlName": "can-i-read-your-papermagazines-online",
-          |        "title": "Can I read your paper/magazines online?",
-          |        "id": "id2",
-          |        "dataCategories": [
-          |            {
-          |                "name": "archives__c",
-          |                "label": "Back issues and archives"
-          |            }
-          |        ],
-          |        "body": "<p>We do not</p>"
-          |    }
-          |}""".stripMargin)
-      test("number of files published") {
-        published.map(_.length) ==> Right(3)
+    test("takeDownArticle") {
+      val takeDown = takeDownArticle()("""{
+                                         |    "dataCategories": [
+                                         |        {
+                                         |            "publishedArticles": [
+                                         |                {
+                                         |                    "urlName": "id-like-to-make-a-complaint-about-an-advertisement",
+                                         |                    "title": "I'd like to make a complaint about an advertisement",
+                                         |                    "id": "id1",
+                                         |                    "dataCategories": [],
+                                         |                    "body": null
+                                         |                },
+                                         |                {
+                                         |                    "urlName": "can-i-read-your-papermagazines-online",
+                                         |                    "title": "Can I read your paper/magazines online?",
+                                         |                    "id": "id2",
+                                         |                    "dataCategories": [],
+                                         |                    "body": null
+                                         |                },
+                                         |                {
+                                         |                    "urlName": "im-unable-to-comment-and-need-help",
+                                         |                    "title": "I'm unable to comment and need help",
+                                         |                    "id": "id3",
+                                         |                    "dataCategories": [],
+                                         |                    "body": null
+                                         |                }
+                                         |            ],
+                                         |            "name": "apps__c"
+                                         |        }
+                                         |    ],
+                                         |    "article": {
+                                         |        "urlName": "can-i-read-your-papermagazines-online",
+                                         |        "title": "Can I read your paper/magazines online?",
+                                         |        "id": "id2",
+                                         |        "dataCategories": [
+                                         |            {
+                                         |                "name": "apps__c",
+                                         |                "label": "The Guardian apps"
+                                         |            }
+                                         |        ],
+                                         |        "body": "<p>We do not</p>"
+                                         |    }
+                                         |}""".stripMargin)
+      test("Number of files modified") {
+        takeDown.map(_.length) ==> Right(3)
       }
-      test("article published") {
-        published.map(_(0)) ==> Right(
+      test("Article is removed from topics") {
+        takeDown.map(_(0)) ==> Right(
           PathAndContent(
-            "testArticles/can-i-read-your-papermagazines-online",
-            """{"title":"Can I read your paper/magazines online?","body":[{"element":"p","content":[{"element":"text","content":"We do not"}]}],"path":"can-i-read-your-papermagazines-online","topics":[{"path":"archives","title":"Back issues and archives"}]}"""
+            "testTopics/apps",
+            """{"path":"apps","title":"The Guardian apps","articles":[{"path":"how-can-i-redirect-my-delivery","title":"How can I redirect my delivery?"},{"path":"id-like-to-make-a-complaint-about-an-advertisement","title":"I'd like to make a complaint about an advertisement"},{"path":"im-unable-to-comment-and-need-help","title":"I'm unable to comment and need help"}]}"""
           )
         )
       }
-      test("topic published") {
-        published.map(_(1)) ==> Right(
-          PathAndContent(
-            "testTopics/archives",
-            """{"path":"archives","title":"Back issues and archives","articles":[{"path":"can-i-read-your-papermagazines-online","title":"Can I read your paper/magazines online?"},{"path":"id-like-to-make-a-complaint-about-an-advertisement","title":"I'd like to make a complaint about an advertisement"},{"path":"im-unable-to-comment-and-need-help","title":"I'm unable to comment and need help"}]}"""
-          )
-        )
-      }
-      test("More topics published") {
-        published.map(_(2)) ==> Right(
+      test("Article is removed from More topics") {
+        takeDown.map(_(1)) ==> Right(
           PathAndContent(
             "testTopics/more-topics",
-            """{"path":"more-topics","title":"More topics","topics":[{"path":"archives","title":"Back issues and archives","articles":[{"path":"can-i-read-your-papermagazines-online","title":"Can I read your paper/magazines online?"},{"path":"id-like-to-make-a-complaint-about-an-advertisement","title":"I'd like to make a complaint about an advertisement"},{"path":"im-unable-to-comment-and-need-help","title":"I'm unable to comment and need help"}]}]}"""
+            """{"path":"more-topics","title":"More topics","topics":[{"path":"archives","title":"Back issues and archives","articles":[{"path":"b1","title":"Finding articles from the past in digital format"},{"path":"b2","title":"Old newspapers in physical format"}]},{"path":"events","title":"Events","articles":[{"path":"e1","title":"I can no longer attend the live online event, can I have a refund?"},{"path":"e2","title":"I can’t find my original confirmation email, can you resend me the event link?"},{"path":"e3","title":"Once I have purchased a ticket, how will I attend the online event?"},{"path":"e4","title":"I purchased a book with my ticket, when will I receive this?"}]},{"path":"gifting","title":"Gifting","articles":[{"path":"g1","title":"Gifting a Digital Subscription"}]},{"path":"newsletters-and-emails","title":"Newsletters and emails","articles":[{"path":"n1","title":"I'm not receiving any emails from you but think I should be"},{"path":"n2","title":"Manage your email preferences"}]},{"path":"the-guardian-apps","title":"The Guardian apps","articles":[{"path":"a2","title":"Apple/Google subscriptions"},{"path":"a3","title":"Personalising your apps"},{"path":"a1","title":"Premium tier access"}]}]}"""
           )
         )
       }
-    }
-
-    test("Publish article, topic and more topics when article has a non-core topic and 'More topics' is not empty") {
-      val published = publishContents(
-        previousArticles = Map(Fixtures.article2),
-        previousTopics = Map(Fixtures.moreTopics)
-      )(
-        """{
-        |    "dataCategories": [
-        |        {
-        |            "publishedArticles": [
-        |                {
-        |                    "urlName": "id-like-to-make-a-complaint-about-an-advertisement",
-        |                    "title": "I'd like to make a complaint about an advertisement",
-        |                    "id": "id1",
-        |                    "dataCategories": [],
-        |                    "body": null
-        |                },
-        |                {
-        |                    "urlName": "can-i-read-your-papermagazines-online",
-        |                    "title": "Can I read your paper/magazines online?",
-        |                    "id": "id2",
-        |                    "dataCategories": [],
-        |                    "body": null
-        |                },
-        |                {
-        |                    "urlName": "im-unable-to-comment-and-need-help",
-        |                    "title": "I'm unable to comment and need help",
-        |                    "id": "id3",
-        |                    "dataCategories": [],
-        |                    "body": null
-        |                }
-        |            ],
-        |            "name": "archives__c"
-        |        }
-        |    ],
-        |    "article": {
-        |        "urlName": "can-i-read-your-papermagazines-online",
-        |        "title": "Can I read your paper/magazines online?",
-        |        "id": "id2",
-        |        "dataCategories": [
-        |            {
-        |                "name": "archives__c",
-        |                "label": "Back issues and archives"
-        |            }
-        |        ],
-        |        "body": "<p>We do not</p>"
-        |    }
-        |}""".stripMargin
-      )
-      test("number of files published") {
-        published.map(_.length) ==> Right(3)
-      }
-      test("article published") {
-        published.map(_(0)) ==> Right(
-          PathAndContent(
-            "testArticles/can-i-read-your-papermagazines-online",
-            """{"title":"Can I read your paper/magazines online?","body":[{"element":"p","content":[{"element":"text","content":"We do not"}]}],"path":"can-i-read-your-papermagazines-online","topics":[{"path":"archives","title":"Back issues and archives"}]}"""
-          )
-        )
-      }
-      test("topic published") {
-        published.map(_(1)) ==> Right(
-          PathAndContent(
-            "testTopics/archives",
-            """{"path":"archives","title":"Back issues and archives","articles":[{"path":"can-i-read-your-papermagazines-online","title":"Can I read your paper/magazines online?"},{"path":"id-like-to-make-a-complaint-about-an-advertisement","title":"I'd like to make a complaint about an advertisement"},{"path":"im-unable-to-comment-and-need-help","title":"I'm unable to comment and need help"}]}"""
-          )
-        )
-      }
-      test("More topics published") {
-        published.map(_(2)) ==> Right(
-          PathAndContent(
-            "testTopics/more-topics",
-            """{"path":"more-topics","title":"More topics","topics":[{"path":"archives","title":"Back issues and archives","articles":[{"path":"can-i-read-your-papermagazines-online","title":"Can I read your paper/magazines online?"},{"path":"id-like-to-make-a-complaint-about-an-advertisement","title":"I'd like to make a complaint about an advertisement"},{"path":"im-unable-to-comment-and-need-help","title":"I'm unable to comment and need help"}]},{"path":"events","title":"Events","articles":[{"path":"e1","title":"I can no longer attend the live online event, can I have a refund?"},{"path":"e2","title":"I can’t find my original confirmation email, can you resend me the event link?"},{"path":"e3","title":"Once I have purchased a ticket, how will I attend the online event?"},{"path":"e4","title":"I purchased a book with my ticket, when will I receive this?"}]},{"path":"gifting","title":"Gifting","articles":[{"path":"g1","title":"Gifting a Digital Subscription"}]},{"path":"newsletters-and-emails","title":"Newsletters and emails","articles":[{"path":"n1","title":"I'm not receiving any emails from you but think I should be"},{"path":"n2","title":"Manage your email preferences"}]},{"path":"the-guardian-apps","title":"The Guardian apps","articles":[{"path":"a2","title":"Apple/Google subscriptions"},{"path":"a3","title":"Personalising your apps"},{"path":"a1","title":"Premium tier access"}]}]}"""
-          )
-        )
-      }
-    }
-
-    test("When topic has changed, publish article and new topic and remove article from old topic") {
-      val published = publishContents(
-        previousArticles = Map(Fixtures.article1),
-        previousTopics = Map(Fixtures.deliveryTopic)
-      )(
-        """{
-          |    "dataCategories": [
-          |        {
-          |            "publishedArticles": [
-          |                {
-          |                    "urlName": "id-like-to-make-a-complaint-about-an-advertisement",
-          |                    "title": "I'd like to make a complaint about an advertisement",
-          |                    "id": "id1",
-          |                    "dataCategories": [],
-          |                    "body": null
-          |                },
-          |                {
-          |                    "urlName": "how-can-i-redirect-my-delivery",
-          |                    "title": "How can I redirect my delivery?",
-          |                    "id": "id2",
-          |                    "dataCategories": [],
-          |                    "body": null
-          |                },
-          |                {
-          |                    "urlName": "im-unable-to-comment-and-need-help",
-          |                    "title": "I'm unable to comment and need help",
-          |                    "id": "id3",
-          |                    "dataCategories": [],
-          |                    "body": null
-          |                }
-          |            ],
-          |            "name": "website__c"
-          |        }
-          |    ],
-          |    "article": {
-          |        "urlName": "how-can-i-redirect-my-delivery",
-          |        "title": "How can I redirect my delivery?",
-          |        "id": "id2",
-          |        "dataCategories": [
-          |            {
-          |                "name": "website__c",
-          |                "label": "The Guardian website"
-          |            }
-          |        ],
-          |        "body": "<p>We do not</p>"
-          |    }
-          |}""".stripMargin
-      )
-      test("number of files published") {
-        published.map(_.length) ==> Right(3)
-      }
-      test("article published") {
-        published.map(_(0)) ==> Right(
-          PathAndContent(
-            "testArticles/how-can-i-redirect-my-delivery",
-            """{"title":"How can I redirect my delivery?","body":[{"element":"p","content":[{"element":"text","content":"We do not"}]}],"path":"how-can-i-redirect-my-delivery","topics":[{"path":"website","title":"The Guardian website"}]}"""
-          )
-        )
-      }
-      test("topic published") {
-        published.map(_(1)) ==> Right(
-          PathAndContent(
-            "testTopics/website",
-            """{"path":"website","title":"The Guardian website","articles":[{"path":"how-can-i-redirect-my-delivery","title":"How can I redirect my delivery?"},{"path":"id-like-to-make-a-complaint-about-an-advertisement","title":"I'd like to make a complaint about an advertisement"},{"path":"im-unable-to-comment-and-need-help","title":"I'm unable to comment and need help"}]}"""
-          )
-        )
-      }
-      test("topic republished without article") {
-        published.map(_(2)) ==> Right(
-          PathAndContent(
-            "testTopics/delivery",
-            """{"path":"delivery","title":"Delivery","articles":[{"path":"can-i-read-your-papermagazines-online","title":"Can I read your paper/magazines online?"},{"path":"id-like-to-make-a-complaint-about-an-advertisement","title":"I'd like to make a complaint about an advertisement"},{"path":"im-unable-to-comment-and-need-help","title":"I'm unable to comment and need help"}]}"""
-          )
-        )
+      test("Article is deleted") {
+        takeDown.map(_(2)) ==> Right(PathAndContent("testArticles/can-i-read-your-papermagazines-online", ""))
       }
     }
   }

--- a/src/test/scala/managehelpcontentpublisher/PathAndContentTestSuite.scala
+++ b/src/test/scala/managehelpcontentpublisher/PathAndContentTestSuite.scala
@@ -209,9 +209,11 @@ object PathAndContentTestSuite extends TestSuite {
     ) _
 
   private def takeDownArticle(
+      articles: Map[String, String] = Map(Fixtures.article1, Fixtures.article2),
       topics: Map[String, String] = Map(Fixtures.deliveryTopic, Fixtures.appsTopic, Fixtures.moreTopics)
   ) =
     PathAndContent.takeDownArticle(
+      fetchArticleByPath = { path => Right(articles.get(path)) },
       deleteArticleByPath = { path => Right(s"testArticles/$path") },
       fetchTopicByPath = { path => Right(topics.get(path)) },
       storeTopic = { topic => Right(PathAndContent(s"testTopics/${topic.path}", topic.content)) }
@@ -512,48 +514,7 @@ object PathAndContentTestSuite extends TestSuite {
     }
 
     test("takeDownArticle") {
-      val takeDown = takeDownArticle()("""{
-                                         |    "dataCategories": [
-                                         |        {
-                                         |            "publishedArticles": [
-                                         |                {
-                                         |                    "urlName": "id-like-to-make-a-complaint-about-an-advertisement",
-                                         |                    "title": "I'd like to make a complaint about an advertisement",
-                                         |                    "id": "id1",
-                                         |                    "dataCategories": [],
-                                         |                    "body": null
-                                         |                },
-                                         |                {
-                                         |                    "urlName": "can-i-read-your-papermagazines-online",
-                                         |                    "title": "Can I read your paper/magazines online?",
-                                         |                    "id": "id2",
-                                         |                    "dataCategories": [],
-                                         |                    "body": null
-                                         |                },
-                                         |                {
-                                         |                    "urlName": "im-unable-to-comment-and-need-help",
-                                         |                    "title": "I'm unable to comment and need help",
-                                         |                    "id": "id3",
-                                         |                    "dataCategories": [],
-                                         |                    "body": null
-                                         |                }
-                                         |            ],
-                                         |            "name": "apps__c"
-                                         |        }
-                                         |    ],
-                                         |    "article": {
-                                         |        "urlName": "can-i-read-your-papermagazines-online",
-                                         |        "title": "Can I read your paper/magazines online?",
-                                         |        "id": "id2",
-                                         |        "dataCategories": [
-                                         |            {
-                                         |                "name": "apps__c",
-                                         |                "label": "The Guardian apps"
-                                         |            }
-                                         |        ],
-                                         |        "body": "<p>We do not</p>"
-                                         |    }
-                                         |}""".stripMargin)
+      val takeDown = takeDownArticle()("can-i-read-your-papermagazines-online")
       test("Number of files modified") {
         takeDown.map(_.length) ==> Right(3)
       }


### PR DESCRIPTION
This change adds an [endpoint to the publisher to make takedown requests](https://github.com/guardian/manage-help-content-publisher/compare/kc-takedown?expand=1#diff-fa38c37d169b2fe9b07d85161af66c2ffe555173b5b6dad88ae3884e4e7e0410R115-R116).

To take down an article, we:
1. [re-publish topic pages omitting the article](https://github.com/guardian/manage-help-content-publisher/compare/kc-takedown?expand=1#diff-db09425e7d17a397436623627dbbc7263593c7c21d5cc87a63ef7a59b4d5ce31R132)
1. [re-publish the more topics page omitting the article](https://github.com/guardian/manage-help-content-publisher/compare/kc-takedown?expand=1#diff-db09425e7d17a397436623627dbbc7263593c7c21d5cc87a63ef7a59b4d5ce31R133)
1. [delete the article](https://github.com/guardian/manage-help-content-publisher/compare/kc-takedown?expand=1#diff-db09425e7d17a397436623627dbbc7263593c7c21d5cc87a63ef7a59b4d5ce31R134)

This should trigger the appropriate 404 behaviour in manage-frontend.
