### PR TITLE
Add build number to log entries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,20 @@
 import Dependencies._
+import com.gu.riffraff.artifact.BuildInfo
 
 ThisBuild / scalaVersion := "2.13.5"
 
+val buildInfo = Seq(
+  buildInfoPackage := "build",
+  buildInfoKeys ++= {
+    val buildInfo = BuildInfo(baseDirectory.value)
+    Seq[BuildInfoKey](
+      "buildNumber" -> buildInfo.buildIdentifier
+    )
+  }
+)
+
 lazy val root = (project in file("."))
-  .enablePlugins(RiffRaffArtifact)
+  .enablePlugins(BuildInfoPlugin, RiffRaffArtifact)
   .settings(
     name := "manage-help-content-publisher",
     assemblyJarName := s"${name.value}.jar",
@@ -12,6 +23,7 @@ lazy val root = (project in file("."))
     riffRaffUploadManifestBucket := Option("riffraff-builds"),
     riffRaffManifestProjectName := s"${name.value}",
     riffRaffArtifactResources += (file("cfn.yaml"), "cfn/cfn.yaml"),
+    buildInfo,
     libraryDependencies ++= Seq(
       http,
       circeCore,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.12")
 addSbtPlugin("com.github.cb372" % "sbt-explicit-dependencies" % "0.2.16")

--- a/src/main/scala/managehelpcontentpublisher/Logging.scala
+++ b/src/main/scala/managehelpcontentpublisher/Logging.scala
@@ -1,5 +1,6 @@
 package managehelpcontentpublisher
 
+import build.BuildInfo.buildNumber
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.events.{APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent}
 import ujson.Obj
@@ -7,7 +8,7 @@ import ujson.Obj
 object Logging {
 
   private def log(context: Context, level: String, otherFields: Obj): Unit =
-    context.getLogger.log(add(otherFields, "logLevel" -> level).render())
+    context.getLogger.log(add(add(otherFields, "logLevel" -> level), "build" -> buildNumber).render())
 
   private def logInfo(context: Context, event: String, fields: Obj): Unit =
     log(context, "INFO", add(fields, "event" -> event))


### PR DESCRIPTION
This helps us to understand where we are by adding the Teamcity build number, or whichever build number Riffraff uses, to  Cloudwatch log entries.
Entries now appear like this:
`{"build":"80","logLevel":"INFO","event":"Request","body":"...`
