### PR TITLE
Update sitemap when an article is published

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,8 @@ import com.gu.riffraff.artifact.BuildInfo
 
 ThisBuild / scalaVersion := "2.13.6"
 
+ThisBuild / scalacOptions += "-deprecation"
+
 val buildInfo = Seq(
   buildInfoPackage := "build",
   buildInfoKeys ++= {

--- a/src/main/scala/managehelpcontentpublisher/Config.scala
+++ b/src/main/scala/managehelpcontentpublisher/Config.scala
@@ -5,13 +5,19 @@ import software.amazon.awssdk.regions.Region.EU_WEST_1
 
 import scala.sys.env
 
-case class Config(stage: String, topic: TopicConfig, aws: AwsConfig)
+case class Config(stage: String, topic: TopicConfig, aws: AwsConfig, articleUrlPrefix: String)
 
 case class TopicConfig(corePaths: Set[String], moreTopics: MoreTopicsConfig)
 
 case class MoreTopicsConfig(path: String, title: String)
 
-case class AwsConfig(region: Region, bucketName: String, articlesFolder: String, topicsFolder: String)
+case class AwsConfig(
+    region: Region,
+    bucketName: String,
+    articlesFolder: String,
+    topicsFolder: String,
+    sitemapFile: String
+)
 
 object Config {
 
@@ -37,7 +43,16 @@ object Config {
       region = EU_WEST_1,
       bucketName = "manage-help-content",
       articlesFolder = s"$stage/articles",
-      topicsFolder = s"$stage/topics"
-    )
+      topicsFolder = s"$stage/topics",
+      sitemapFile = s"$stage/sitemap.txt"
+    ),
+    articleUrlPrefix = {
+      val domain = stage match {
+        case "PROD" => "manage.theguardian.com"
+        case "CODE" => "manage.code.dev-theguardian.com"
+        case _      => "manage.thegulocal.com"
+      }
+      s"https://$domain/help-centre/article"
+    }
   )
 }

--- a/src/main/scala/managehelpcontentpublisher/PublishingOps.scala
+++ b/src/main/scala/managehelpcontentpublisher/PublishingOps.scala
@@ -1,5 +1,7 @@
 package managehelpcontentpublisher
 
+import java.net.URI
+
 /** Operations to read and write content to and from storage accessible to the web layer.
   */
 trait PublishingOps {
@@ -14,6 +16,8 @@ trait PublishingOps {
     */
   def fetchTopicByPath(path: String): Either[Failure, Option[String]]
 
+  def fetchSitemap(): Either[Failure, Set[URI]]
+
   /** Stores the published representation of an article so that it's available to the web layer.
     */
   def storeArticle(pathAndContent: PathAndContent): Either[Failure, PathAndContent]
@@ -21,6 +25,8 @@ trait PublishingOps {
   /** Stores the published representation of a topic so that it's available to the web layer.
     */
   def storeTopic(pathAndContent: PathAndContent): Either[Failure, PathAndContent]
+
+  def storeSitemap(urls: Set[URI]): Either[Failure, Unit]
 
   /** Deletes the published representation of an article.
     */

--- a/src/test/resources/sitemap.txt
+++ b/src/test/resources/sitemap.txt
@@ -1,0 +1,3 @@
+https://manage.thegulocal.com/help-centre/article/article1
+https://manage.thegulocal.com/help-centre/article/article2
+https://manage.thegulocal.com/help-centre/article/article3

--- a/src/test/scala/managehelpcontentpublisher/PathAndContentTestSuite.scala
+++ b/src/test/scala/managehelpcontentpublisher/PathAndContentTestSuite.scala
@@ -3,6 +3,9 @@ package managehelpcontentpublisher
 import managehelpcontentpublisher.Config.config
 import utest._
 
+import java.net.URI
+import scala.io.Source
+
 /** See [[https://github.com/guardian/salesforce/blob/master/force-app/main/default/classes/ArticleBodyValidation.cls#L5-L20 list of HTML elements we support in Salesforce]].
   */
 object PathAndContentTestSuite extends TestSuite {
@@ -195,6 +198,8 @@ object PathAndContentTestSuite extends TestSuite {
       |    }
       |  ]
       |}""".stripMargin
+
+    val sitemap: Set[URI] = Source.fromResource("sitemap.txt").getLines().map(new URI(_)).toSet
   }
 
   private def publishContents(
@@ -203,15 +208,20 @@ object PathAndContentTestSuite extends TestSuite {
   ) =
     PathAndContent.publishContents(
       new PublishingOps {
+
         def fetchArticleByPath(path: String): Either[Failure, Option[String]] = Right(previousArticles.get(path))
 
         def fetchTopicByPath(path: String): Either[Failure, Option[String]] = Right(previousTopics.get(path))
+
+        def fetchSitemap(): Either[Failure, Set[URI]] = Right(Fixtures.sitemap)
 
         def storeArticle(pathAndContent: PathAndContent): Either[Failure, PathAndContent] =
           Right(PathAndContent(s"testArticles/${pathAndContent.path}", pathAndContent.content))
 
         def storeTopic(pathAndContent: PathAndContent): Either[Failure, PathAndContent] =
           Right(PathAndContent(s"testTopics/${pathAndContent.path}", pathAndContent.content))
+
+        def storeSitemap(urls: Set[URI]): Either[Failure, Unit] = Right(())
 
         def deleteArticleByPath(path: String): Either[Failure, String] = Left(NotFoundFailure)
       }
@@ -223,15 +233,20 @@ object PathAndContentTestSuite extends TestSuite {
   ) =
     PathAndContent.takeDownArticle(
       new PublishingOps {
+
         def fetchArticleByPath(path: String): Either[Failure, Option[String]] = Right(articles.get(path))
 
         def fetchTopicByPath(path: String): Either[Failure, Option[String]] = Right(topics.get(path))
+
+        def fetchSitemap(): Either[Failure, Set[URI]] = Right(Fixtures.sitemap)
 
         def storeArticle(pathAndContent: PathAndContent): Either[Failure, PathAndContent] =
           Left(RequestFailure("unexpected"))
 
         def storeTopic(pathAndContent: PathAndContent): Either[Failure, PathAndContent] =
           Right(PathAndContent(s"testTopics/${pathAndContent.path}", pathAndContent.content))
+
+        def storeSitemap(urls: Set[URI]): Either[Failure, Unit] = Right(())
 
         def deleteArticleByPath(path: String): Either[Failure, String] = Right(s"testArticles/$path")
       }
@@ -284,7 +299,7 @@ object PathAndContentTestSuite extends TestSuite {
             |    }
             |}""".stripMargin)
         test("number of files published") {
-          published.map(_.length) ==> Right(2)
+          published.map(_.length) ==> Right(3)
         }
         test("article published") {
           published.map(_(0)) ==> Right(
@@ -299,6 +314,17 @@ object PathAndContentTestSuite extends TestSuite {
             PathAndContent(
               "testTopics/website",
               """{"path":"website","title":"The Guardian website","articles":[{"path":"can-i-read-your-papermagazines-online","title":"Can I read your paper/magazines online?"},{"path":"id-like-to-make-a-complaint-about-an-advertisement","title":"I'd like to make a complaint about an advertisement"},{"path":"im-unable-to-comment-and-need-help","title":"I'm unable to comment and need help"}]}"""
+            )
+          )
+        }
+        test("sitemap updated") {
+          published.map(_(2)) ==> Right(
+            PathAndContent(
+              "DEV/sitemap.txt",
+              """https://manage.thegulocal.com/help-centre/article/article1
+                |https://manage.thegulocal.com/help-centre/article/article2
+                |https://manage.thegulocal.com/help-centre/article/article3
+                |https://manage.thegulocal.com/help-centre/article/can-i-read-your-papermagazines-online""".stripMargin
             )
           )
         }
@@ -348,7 +374,7 @@ object PathAndContentTestSuite extends TestSuite {
             |    }
             |}""".stripMargin)
         test("number of files published") {
-          published.map(_.length) ==> Right(3)
+          published.map(_.length) ==> Right(4)
         }
         test("article published") {
           published.map(_(0)) ==> Right(
@@ -371,6 +397,17 @@ object PathAndContentTestSuite extends TestSuite {
             PathAndContent(
               "testTopics/more-topics",
               """{"path":"more-topics","title":"More topics","topics":[{"path":"archives","title":"Back issues and archives","articles":[{"path":"can-i-read-your-papermagazines-online","title":"Can I read your paper/magazines online?"},{"path":"id-like-to-make-a-complaint-about-an-advertisement","title":"I'd like to make a complaint about an advertisement"},{"path":"im-unable-to-comment-and-need-help","title":"I'm unable to comment and need help"}]}]}"""
+            )
+          )
+        }
+        test("sitemap updated") {
+          published.map(_(3)) ==> Right(
+            PathAndContent(
+              "DEV/sitemap.txt",
+              """https://manage.thegulocal.com/help-centre/article/article1
+                |https://manage.thegulocal.com/help-centre/article/article2
+                |https://manage.thegulocal.com/help-centre/article/article3
+                |https://manage.thegulocal.com/help-centre/article/can-i-read-your-papermagazines-online""".stripMargin
             )
           )
         }
@@ -425,7 +462,7 @@ object PathAndContentTestSuite extends TestSuite {
             |}""".stripMargin
         )
         test("number of files published") {
-          published.map(_.length) ==> Right(3)
+          published.map(_.length) ==> Right(4)
         }
         test("article published") {
           published.map(_(0)) ==> Right(
@@ -448,6 +485,17 @@ object PathAndContentTestSuite extends TestSuite {
             PathAndContent(
               "testTopics/more-topics",
               """{"path":"more-topics","title":"More topics","topics":[{"path":"archives","title":"Back issues and archives","articles":[{"path":"can-i-read-your-papermagazines-online","title":"Can I read your paper/magazines online?"},{"path":"id-like-to-make-a-complaint-about-an-advertisement","title":"I'd like to make a complaint about an advertisement"},{"path":"im-unable-to-comment-and-need-help","title":"I'm unable to comment and need help"}]},{"path":"events","title":"Events","articles":[{"path":"e1","title":"I can no longer attend the live online event, can I have a refund?"},{"path":"e2","title":"I can’t find my original confirmation email, can you resend me the event link?"},{"path":"e3","title":"Once I have purchased a ticket, how will I attend the online event?"},{"path":"e4","title":"I purchased a book with my ticket, when will I receive this?"}]},{"path":"gifting","title":"Gifting","articles":[{"path":"g1","title":"Gifting a Digital Subscription"}]},{"path":"newsletters-and-emails","title":"Newsletters and emails","articles":[{"path":"n1","title":"I'm not receiving any emails from you but think I should be"},{"path":"n2","title":"Manage your email preferences"}]},{"path":"the-guardian-apps","title":"The Guardian apps","articles":[{"path":"a2","title":"Apple/Google subscriptions"},{"path":"a3","title":"Personalising your apps"},{"path":"a1","title":"Premium tier access"}]}]}"""
+            )
+          )
+        }
+        test("sitemap updated") {
+          published.map(_(3)) ==> Right(
+            PathAndContent(
+              "DEV/sitemap.txt",
+              """https://manage.thegulocal.com/help-centre/article/article1
+                |https://manage.thegulocal.com/help-centre/article/article2
+                |https://manage.thegulocal.com/help-centre/article/article3
+                |https://manage.thegulocal.com/help-centre/article/can-i-read-your-papermagazines-online""".stripMargin
             )
           )
         }
@@ -502,7 +550,7 @@ object PathAndContentTestSuite extends TestSuite {
             |}""".stripMargin
         )
         test("number of files published") {
-          published.map(_.length) ==> Right(3)
+          published.map(_.length) ==> Right(4)
         }
         test("article published") {
           published.map(_(0)) ==> Right(
@@ -525,6 +573,17 @@ object PathAndContentTestSuite extends TestSuite {
             PathAndContent(
               "testTopics/delivery",
               """{"path":"delivery","title":"Delivery","articles":[{"path":"can-i-read-your-papermagazines-online","title":"Can I read your paper/magazines online?"},{"path":"id-like-to-make-a-complaint-about-an-advertisement","title":"I'd like to make a complaint about an advertisement"},{"path":"im-unable-to-comment-and-need-help","title":"I'm unable to comment and need help"}]}"""
+            )
+          )
+        }
+        test("sitemap updated") {
+          published.map(_(3)) ==> Right(
+            PathAndContent(
+              "DEV/sitemap.txt",
+              """https://manage.thegulocal.com/help-centre/article/article1
+                |https://manage.thegulocal.com/help-centre/article/article2
+                |https://manage.thegulocal.com/help-centre/article/article3
+                |https://manage.thegulocal.com/help-centre/article/how-can-i-redirect-my-delivery""".stripMargin
             )
           )
         }


### PR DESCRIPTION
In this context, a sitemap is just considered to be a set of URLs that we want bots to index.  So specifically it's going to be a list of article URLs.
When an article is published or re-published, we check the sitemap to see if the article is already in the list.  If it isn't there, we add it.

This has been tested in the Dev stage.

In another PR, we will ping Google whenever an article is published, regardless of whether the sitemap has changed, so that it will reindex the content.

See:
https://developers.google.com/search/docs/advanced/sitemaps/build-sitemap
