### PR TITLE
Remove article from sitemap on takedown

### DIFF
--- a/src/test/resources/articles/changing-my-contribution-amount.json
+++ b/src/test/resources/articles/changing-my-contribution-amount.json
@@ -1,0 +1,44 @@
+{
+  "title": "Changing my contribution amount",
+  "body": [
+    {
+      "element": "p",
+      "content": [
+        {
+          "element": "text",
+          "content": "If your contribution is recurring, you can change the amount you pay by logging into your "
+        },
+        {
+          "element": "a",
+          "content": [
+            {
+              "element": "text",
+              "content": "Manage My Account "
+            }
+          ],
+          "href": "https://manage.theguardian.com/"
+        },
+        {
+          "element": "text",
+          "content": "area. You will need to sign in using the email address you registered with."
+        }
+      ]
+    },
+    {
+      "element": "p",
+      "content": [
+        {
+          "element": "text",
+          "content": "Select “Manage recurring contribution” and then “change amount” to select another value."
+        }
+      ]
+    }
+  ],
+  "path": "changing-my-contribution-amount",
+  "topics": [
+    {
+      "path": "apps",
+      "title": "Apps"
+    }
+  ]
+}

--- a/src/test/resources/sitemap.txt
+++ b/src/test/resources/sitemap.txt
@@ -1,3 +1,4 @@
 https://manage.thegulocal.com/help-centre/article/article1
 https://manage.thegulocal.com/help-centre/article/article2
+https://manage.thegulocal.com/help-centre/article/changing-my-contribution-amount
 https://manage.thegulocal.com/help-centre/article/article3

--- a/src/test/resources/topics/apps.json
+++ b/src/test/resources/topics/apps.json
@@ -17,6 +17,10 @@
     {
       "path": "im-unable-to-comment-and-need-help",
       "title": "I'm unable to comment and need help"
+    },
+    {
+      "path": "changing-my-contribution-amount",
+      "title": "Changing my contribution amount"
     }
   ]
 }

--- a/src/test/resources/topics/more-topics.json
+++ b/src/test/resources/topics/more-topics.json
@@ -21,6 +21,10 @@
         {
           "path": "a1",
           "title": "Premium tier access"
+        },
+        {
+          "path": "changing-my-contribution-amount",
+          "title": "Changing my contribution amount"
         }
       ]
     },

--- a/src/test/scala/managehelpcontentpublisher/PathAndContentTestSuite.scala
+++ b/src/test/scala/managehelpcontentpublisher/PathAndContentTestSuite.scala
@@ -18,6 +18,7 @@ object PathAndContentTestSuite extends TestSuite {
 
     val article1: (String, String) = article("how-can-i-redirect-my-delivery")
     val article2: (String, String) = article("can-i-read-your-papermagazines-online")
+    val article3: (String, String) = article("changing-my-contribution-amount")
     val deliveryTopic: (String, String) = topic("delivery")
     val appsTopic: (String, String) = topic("apps")
     val moreTopics: (String, String) = topic("more-topics")
@@ -50,7 +51,7 @@ object PathAndContentTestSuite extends TestSuite {
     ) _
 
   private def takeDownArticle(
-      articles: Map[String, String] = Map(Fixtures.article1, Fixtures.article2),
+      articles: Map[String, String] = Map(Fixtures.article1, Fixtures.article2, Fixtures.article3),
       topics: Map[String, String] = Map(Fixtures.deliveryTopic, Fixtures.appsTopic, Fixtures.moreTopics)
   ) =
     PathAndContent.takeDownArticle(
@@ -146,7 +147,8 @@ object PathAndContentTestSuite extends TestSuite {
               """https://manage.thegulocal.com/help-centre/article/article1
                 |https://manage.thegulocal.com/help-centre/article/article2
                 |https://manage.thegulocal.com/help-centre/article/article3
-                |https://manage.thegulocal.com/help-centre/article/can-i-read-your-papermagazines-online""".stripMargin
+                |https://manage.thegulocal.com/help-centre/article/can-i-read-your-papermagazines-online
+                |https://manage.thegulocal.com/help-centre/article/changing-my-contribution-amount""".stripMargin
             )
           )
         }
@@ -229,7 +231,8 @@ object PathAndContentTestSuite extends TestSuite {
               """https://manage.thegulocal.com/help-centre/article/article1
                 |https://manage.thegulocal.com/help-centre/article/article2
                 |https://manage.thegulocal.com/help-centre/article/article3
-                |https://manage.thegulocal.com/help-centre/article/can-i-read-your-papermagazines-online""".stripMargin
+                |https://manage.thegulocal.com/help-centre/article/can-i-read-your-papermagazines-online
+                |https://manage.thegulocal.com/help-centre/article/changing-my-contribution-amount""".stripMargin
             )
           )
         }
@@ -306,7 +309,7 @@ object PathAndContentTestSuite extends TestSuite {
           published.map(_(2)) ==> Right(
             PathAndContent(
               "testTopics/more-topics",
-              """{"path":"more-topics","title":"More topics","topics":[{"path":"archives","title":"Back issues and archives","articles":[{"path":"can-i-read-your-papermagazines-online","title":"Can I read your paper/magazines online?"},{"path":"id-like-to-make-a-complaint-about-an-advertisement","title":"I'd like to make a complaint about an advertisement"},{"path":"im-unable-to-comment-and-need-help","title":"I'm unable to comment and need help"}]},{"path":"events","title":"Events","articles":[{"path":"e1","title":"I can no longer attend the live online event, can I have a refund?"},{"path":"e2","title":"I can’t find my original confirmation email, can you resend me the event link?"},{"path":"e3","title":"Once I have purchased a ticket, how will I attend the online event?"},{"path":"e4","title":"I purchased a book with my ticket, when will I receive this?"}]},{"path":"gifting","title":"Gifting","articles":[{"path":"g1","title":"Gifting a Digital Subscription"}]},{"path":"newsletters-and-emails","title":"Newsletters and emails","articles":[{"path":"n1","title":"I'm not receiving any emails from you but think I should be"},{"path":"n2","title":"Manage your email preferences"}]},{"path":"the-guardian-apps","title":"The Guardian apps","articles":[{"path":"a2","title":"Apple/Google subscriptions"},{"path":"a3","title":"Personalising your apps"},{"path":"a1","title":"Premium tier access"}]}]}"""
+              """{"path":"more-topics","title":"More topics","topics":[{"path":"archives","title":"Back issues and archives","articles":[{"path":"can-i-read-your-papermagazines-online","title":"Can I read your paper/magazines online?"},{"path":"id-like-to-make-a-complaint-about-an-advertisement","title":"I'd like to make a complaint about an advertisement"},{"path":"im-unable-to-comment-and-need-help","title":"I'm unable to comment and need help"}]},{"path":"events","title":"Events","articles":[{"path":"e1","title":"I can no longer attend the live online event, can I have a refund?"},{"path":"e2","title":"I can’t find my original confirmation email, can you resend me the event link?"},{"path":"e3","title":"Once I have purchased a ticket, how will I attend the online event?"},{"path":"e4","title":"I purchased a book with my ticket, when will I receive this?"}]},{"path":"gifting","title":"Gifting","articles":[{"path":"g1","title":"Gifting a Digital Subscription"}]},{"path":"newsletters-and-emails","title":"Newsletters and emails","articles":[{"path":"n1","title":"I'm not receiving any emails from you but think I should be"},{"path":"n2","title":"Manage your email preferences"}]},{"path":"the-guardian-apps","title":"The Guardian apps","articles":[{"path":"a2","title":"Apple/Google subscriptions"},{"path":"a3","title":"Personalising your apps"},{"path":"a1","title":"Premium tier access"},{"path":"changing-my-contribution-amount","title":"Changing my contribution amount"}]}]}""".stripMargin
             )
           )
         }
@@ -317,7 +320,8 @@ object PathAndContentTestSuite extends TestSuite {
               """https://manage.thegulocal.com/help-centre/article/article1
                 |https://manage.thegulocal.com/help-centre/article/article2
                 |https://manage.thegulocal.com/help-centre/article/article3
-                |https://manage.thegulocal.com/help-centre/article/can-i-read-your-papermagazines-online""".stripMargin
+                |https://manage.thegulocal.com/help-centre/article/can-i-read-your-papermagazines-online
+                |https://manage.thegulocal.com/help-centre/article/changing-my-contribution-amount""".stripMargin
             )
           )
         }
@@ -405,6 +409,7 @@ object PathAndContentTestSuite extends TestSuite {
               """https://manage.thegulocal.com/help-centre/article/article1
                 |https://manage.thegulocal.com/help-centre/article/article2
                 |https://manage.thegulocal.com/help-centre/article/article3
+                |https://manage.thegulocal.com/help-centre/article/changing-my-contribution-amount
                 |https://manage.thegulocal.com/help-centre/article/how-can-i-redirect-my-delivery""".stripMargin
             )
           )
@@ -413,15 +418,15 @@ object PathAndContentTestSuite extends TestSuite {
     }
 
     test("takeDownArticle") {
-      val takeDown = takeDownArticle()("can-i-read-your-papermagazines-online")
+      val takeDown = takeDownArticle()("changing-my-contribution-amount")
       test("Number of files modified") {
-        takeDown.map(_.length) ==> Right(3)
+        takeDown.map(_.length) ==> Right(4)
       }
       test("Article is removed from topics") {
         takeDown.map(_(0)) ==> Right(
           PathAndContent(
             "testTopics/apps",
-            """{"path":"apps","title":"The Guardian apps","articles":[{"path":"how-can-i-redirect-my-delivery","title":"How can I redirect my delivery?"},{"path":"id-like-to-make-a-complaint-about-an-advertisement","title":"I'd like to make a complaint about an advertisement"},{"path":"im-unable-to-comment-and-need-help","title":"I'm unable to comment and need help"}]}"""
+            """{"path":"apps","title":"The Guardian apps","articles":[{"path":"can-i-read-your-papermagazines-online","title":"Can I read your paper/magazines online?"},{"path":"how-can-i-redirect-my-delivery","title":"How can I redirect my delivery?"},{"path":"id-like-to-make-a-complaint-about-an-advertisement","title":"I'd like to make a complaint about an advertisement"},{"path":"im-unable-to-comment-and-need-help","title":"I'm unable to comment and need help"}]}"""
           )
         )
       }
@@ -429,12 +434,22 @@ object PathAndContentTestSuite extends TestSuite {
         takeDown.map(_(1)) ==> Right(
           PathAndContent(
             "testTopics/more-topics",
-            """{"path":"more-topics","title":"More topics","topics":[{"path":"archives","title":"Back issues and archives","articles":[{"path":"b1","title":"Finding articles from the past in digital format"},{"path":"b2","title":"Old newspapers in physical format"}]},{"path":"events","title":"Events","articles":[{"path":"e1","title":"I can no longer attend the live online event, can I have a refund?"},{"path":"e2","title":"I can’t find my original confirmation email, can you resend me the event link?"},{"path":"e3","title":"Once I have purchased a ticket, how will I attend the online event?"},{"path":"e4","title":"I purchased a book with my ticket, when will I receive this?"}]},{"path":"gifting","title":"Gifting","articles":[{"path":"g1","title":"Gifting a Digital Subscription"}]},{"path":"newsletters-and-emails","title":"Newsletters and emails","articles":[{"path":"n1","title":"I'm not receiving any emails from you but think I should be"},{"path":"n2","title":"Manage your email preferences"}]},{"path":"the-guardian-apps","title":"The Guardian apps","articles":[{"path":"a2","title":"Apple/Google subscriptions"},{"path":"a3","title":"Personalising your apps"},{"path":"a1","title":"Premium tier access"}]}]}"""
+            """{"path":"more-topics","title":"More topics","topics":[{"path":"archives","title":"Back issues and archives","articles":[{"path":"b1","title":"Finding articles from the past in digital format"},{"path":"b2","title":"Old newspapers in physical format"}]},{"path":"events","title":"Events","articles":[{"path":"e1","title":"I can no longer attend the live online event, can I have a refund?"},{"path":"e2","title":"I can’t find my original confirmation email, can you resend me the event link?"},{"path":"e3","title":"Once I have purchased a ticket, how will I attend the online event?"},{"path":"e4","title":"I purchased a book with my ticket, when will I receive this?"}]},{"path":"gifting","title":"Gifting","articles":[{"path":"g1","title":"Gifting a Digital Subscription"}]},{"path":"newsletters-and-emails","title":"Newsletters and emails","articles":[{"path":"n1","title":"I'm not receiving any emails from you but think I should be"},{"path":"n2","title":"Manage your email preferences"}]},{"path":"the-guardian-apps","title":"The Guardian apps","articles":[{"path":"a2","title":"Apple/Google subscriptions"},{"path":"can-i-read-your-papermagazines-online","title":"Can I read your paper/magazines online?"},{"path":"a3","title":"Personalising your apps"},{"path":"a1","title":"Premium tier access"}]}]}"""
           )
         )
       }
       test("Article is deleted") {
-        takeDown.map(_(2)) ==> Right(PathAndContent("testArticles/can-i-read-your-papermagazines-online", ""))
+        takeDown.map(_(2)) ==> Right(PathAndContent("testArticles/changing-my-contribution-amount", ""))
+      }
+      test("Article is removed from sitemap") {
+        takeDown.map(_(3)) ==> Right(
+          PathAndContent(
+            "DEV/sitemap.txt",
+            """https://manage.thegulocal.com/help-centre/article/article1
+            |https://manage.thegulocal.com/help-centre/article/article2
+            |https://manage.thegulocal.com/help-centre/article/article3""".stripMargin
+          )
+        )
       }
     }
   }


### PR DESCRIPTION
As part of the [taking-down process](https://github.com/guardian/manage-help-content-publisher/compare/kc-sitemap?expand=1#diff-db09425e7d17a397436623627dbbc7263593c7c21d5cc87a63ef7a59b4d5ce31R123-R145), we [remove the article from the sitemap](https://github.com/guardian/manage-help-content-publisher/compare/kc-sitemap?expand=1#diff-db09425e7d17a397436623627dbbc7263593c7c21d5cc87a63ef7a59b4d5ce31R125-R131).

The rest of this change is test code.

See also #114 
