### PR TITLE
Convert line-breaks from HTML to Json correctly

### DIFF
--- a/src/main/scala/managehelpcontentpublisher/HtmlToJson.scala
+++ b/src/main/scala/managehelpcontentpublisher/HtmlToJson.scala
@@ -8,60 +8,23 @@ import scala.jdk.CollectionConverters._
 
 object HtmlToJson {
 
+  import managehelpcontentpublisher.Html._
+
   def apply(html: String): ujson.Value = {
-    val body = Jsoup.parseBodyFragment(html.trim).body
+    def naiveLineBreakToParagraph(s: String) = {
+      val replaced = html.trim.replaceAll("<br[^>]*>", "</p><p>")
+      s"<p>$replaced</p>"
+    }
+    val body = Jsoup.parseBodyFragment(naiveLineBreakToParagraph(html)).body
     htmlToJson(refined(body)).obj("content")
   }
 
-  private def refined(body: Element): Element = {
-
-    def blankTextNodesRemoved(e: Element): Element = {
-
-      def go(acc: Set[TextNode])(curr: Node): Set[TextNode] =
-        curr match {
-          case t: TextNode if t.isBlank => acc + t
-          case _: TextNode              => acc
-          case e: Element =>
-            e.childNodes.asScala.flatMap(go(acc)).toSet
-        }
-
-      val cleaned = e.clone()
-      val blankText = go(Set.empty)(cleaned)
-      blankText.foreach(_.remove())
-      cleaned
-    }
-
-    def unsupportedAttributesRemoved(e: Element): Element =
-      Jsoup.parseBodyFragment(Jsoup.clean(e.outerHtml, Whitelist.relaxed())).body
-
-    def lineBreaksRemoved(e: Element): Element = {
-
-      def remove(br: Element): Unit = {
-        Option(br.previousSibling).foreach(_.wrap("<p>"))
-        Option(br.nextSibling).foreach(_.wrap("<p>"))
-        br.remove()
-      }
-
-      val cleaned = e.clone()
-      val lineBreaks = cleaned.select("br").asScala.toSet
-      for (break <- lineBreaks) remove(break)
-      cleaned
-    }
-
-    def emptyParagraphsRemoved(e: Element): Element = {
-      val cleaned = e.clone()
-      val emptyParas = cleaned.select("p:empty").asScala.toSet
-      for (para <- emptyParas) para.remove()
-      cleaned
-    }
-
+  private def refined(body: Element): Element =
     (
-      lineBreaksRemoved _ andThen
-        unsupportedAttributesRemoved andThen
+      unsupportedAttributesRemoved _ andThen
         blankTextNodesRemoved andThen
         emptyParagraphsRemoved
     )(body)
-  }
 
   private def htmlToJson(n: Node): ujson.Value =
     n match {
@@ -75,11 +38,40 @@ object HtmlToJson {
       "content" -> e.childNodes.asScala.toList.map(htmlToJson)
     )
     e.attributes.asList.asScala.foldLeft(obj)((acc, attribute) =>
-      acc.copy(acc.value ++ Map(attribute.getKey -> attribute.getValue))
-    )
+        acc.copy(acc.value ++ Map(attribute.getKey -> attribute.getValue))
+      )
   }
 
   private val elementTransformations = Map("strong" -> "b", "em" -> "i")
 
   private def transformed(elementName: String): String = elementTransformations.getOrElse(elementName, elementName)
+}
+
+object Html {
+
+  def blankTextNodesRemoved(e: Element): Element = {
+
+    def go(acc: Set[TextNode])(curr: Node): Set[TextNode] =
+      curr match {
+        case t: TextNode if t.isBlank => acc + t
+        case _: TextNode              => acc
+        case e: Element =>
+          e.childNodes.asScala.flatMap(go(acc)).toSet
+      }
+
+    val cleaned = e.clone()
+    val blankText = go(Set.empty)(cleaned)
+    blankText.foreach(_.remove())
+    cleaned
+  }
+
+  def unsupportedAttributesRemoved(e: Element): Element =
+    Jsoup.parseBodyFragment(Jsoup.clean(e.clone().outerHtml, Whitelist.relaxed())).body
+
+  def emptyParagraphsRemoved(e: Element): Element = {
+    val cleaned = e.clone()
+    val emptyParas = cleaned.select("p:empty").asScala.toSet
+    for (para <- emptyParas) para.remove()
+    cleaned
+  }
 }

--- a/src/test/scala/managehelpcontentpublisher/HtmlToJsonTestSuite.scala
+++ b/src/test/scala/managehelpcontentpublisher/HtmlToJsonTestSuite.scala
@@ -231,24 +231,68 @@ object HtmlToJsonTestSuite extends TestSuite {
                                             |  }
                                             |]""".stripMargin
       }
+      test("in middle of paragraph containing a link") {
+        HtmlToJson("""<p>xyz<br />abc<a href="https://support.theguardian.com/">click here</a>def</p>""")
+          .render(indent = 2) ==>
+          """|[
+             |  {
+             |    "element": "p",
+             |    "content": [
+             |      {
+             |        "element": "text",
+             |        "content": "xyz"
+             |      }
+             |    ]
+             |  },
+             |  {
+             |    "element": "p",
+             |    "content": [
+             |      {
+             |        "element": "text",
+             |        "content": "abc"
+             |      },
+             |      {
+             |        "element": "a",
+             |        "content": [
+             |          {
+             |            "element": "text",
+             |            "content": "click here"
+             |          }
+             |        ],
+             |        "href": "https://support.theguardian.com/"
+             |      },
+             |      {
+             |        "element": "text",
+             |        "content": "def"
+             |      }
+             |    ]
+             |  }
+             |]""".stripMargin
+      }
     }
 
     test("Element a") {
       HtmlToJson(
-        """<a href="https://support.theguardian.com/uk/subscribe/digital" target="_blank">digital subscription</a>"""
+        """<p><a href="https://support.theguardian.com/uk/subscribe/digital" target="_blank">digital subscription</a></p>"""
       )
-        .render(indent = 2) ==> """[
-                                        |  {
-                                        |    "element": "a",
-                                        |    "content": [
-                                        |      {
-                                        |        "element": "text",
-                                        |        "content": "digital subscription"
-                                        |      }
-                                        |    ],
-                                        |    "href": "https://support.theguardian.com/uk/subscribe/digital"
-                                        |  }
-                                        |]""".stripMargin
+        .render(indent = 2) ==>
+        """|[
+           |  {
+           |    "element": "p",
+           |    "content": [
+           |      {
+           |        "element": "a",
+           |        "content": [
+           |          {
+           |            "element": "text",
+           |            "content": "digital subscription"
+           |          }
+           |        ],
+           |        "href": "https://support.theguardian.com/uk/subscribe/digital"
+           |      }
+           |    ]
+           |  }
+           |]""".stripMargin
     }
 
     test("Element b") {


### PR DESCRIPTION
There were problems when a paragraph contained a line-break and a non-block element, such as an anchor element.
We do a naive transformation before beginning, which nudges the HTML block into the right form for further processing.
