### PR TITLE
Configure GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,16 +34,16 @@ jobs:
           java-version: '11'
           cache: 'sbt'
 
-      - name: RiffRaffUpload
-        run: sbt clean riffRaffUpload
+      - name: Compile and package project
+        run: sbt clean assembly
 
-#      - name: Upload to Riff-Raff
-#        uses: guardian/actions-riff-raff@v2
-#        with:
-#          app: manage-help-content-publisher
-#          configPath: ./riff-raff.yaml
-#          contentDirectories: |
-#            cfn:
-#              - ./cfn.yaml
-#            manage-help-content-publisher:
-#              - ./manage-help-content-publisher.jar
+      - name: Upload to Riff-Raff
+        uses: guardian/actions-riff-raff@v2
+        with:
+          app: manage-help-content-publisher
+          configPath: ./riff-raff.yaml
+          contentDirectories: |
+            cfn:
+              - ./cfn.yaml
+            manage-help-content-publisher:
+              - ./manage-help-content-publisher.jar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: Build manage-help-content-publisher
+
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  CI:
+    permissions:
+      id-token: write
+      contents: read
+    name: manage-help-content-publisher build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Env
+        run: env
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: eu-west-1
+          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'corretto'
+          java-version: '11'
+          cache: 'sbt'
+
+      - name: RiffRaffUpload
+        run: sbt clean riffRaffUpload
+
+#      - name: Upload to Riff-Raff
+#        uses: guardian/actions-riff-raff@v2
+#        with:
+#          app: manage-help-content-publisher
+#          configPath: ./riff-raff.yaml
+#          contentDirectories: |
+#            cfn:
+#              - ./cfn.yaml
+#            manage-help-content-publisher:
+#              - ./manage-help-content-publisher.jar

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .bsp
 .idea
 target
+manage-help-content-publisher.jar

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,8 @@ lazy val root = (project in file("."))
   .enablePlugins(BuildInfoPlugin, RiffRaffArtifact)
   .settings(
     name := "manage-help-content-publisher",
-    assemblyJarName := s"${name.value}.jar",
+    assembly / assemblyJarName := s"${name.value}.jar",
+    assembly / assemblyOutputPath := file(s"${(assembly/assemblyJarName).value}"),
     riffRaffPackageType := assembly.value,
     riffRaffUploadArtifactBucket := Option("riffraff-artifact"),
     riffRaffUploadManifestBucket := Option("riffraff-builds"),

--- a/build.sbt
+++ b/build.sbt
@@ -1,32 +1,14 @@
 import Dependencies._
-import com.gu.riffraff.artifact.BuildInfo
 
 ThisBuild / scalaVersion := "2.13.8"
 
 ThisBuild / scalacOptions += "-deprecation"
 
-val buildInfo = Seq(
-  buildInfoPackage := "build",
-  buildInfoKeys ++= {
-    val buildInfo = BuildInfo(baseDirectory.value)
-    Seq[BuildInfoKey](
-      "buildNumber" -> buildInfo.buildIdentifier
-    )
-  }
-)
-
 lazy val root = (project in file("."))
-  .enablePlugins(BuildInfoPlugin, RiffRaffArtifact)
   .settings(
     name := "manage-help-content-publisher",
     assembly / assemblyJarName := s"${name.value}.jar",
     assembly / assemblyOutputPath := file(s"${(assembly/assemblyJarName).value}"),
-    riffRaffPackageType := assembly.value,
-    riffRaffUploadArtifactBucket := Option("riffraff-artifact"),
-    riffRaffUploadManifestBucket := Option("riffraff-builds"),
-    riffRaffManifestProjectName := s"${name.value}",
-    riffRaffArtifactResources += (file("cfn.yaml"), "cfn/cfn.yaml"),
-    buildInfo,
     libraryDependencies ++= Seq(
       http,
       circeCore,

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -8,7 +8,8 @@ Parameters:
     AllowedValues:
       - PROD
       - DEV
-    Default: DEV
+      - CODE
+    Default: CODE
   AppName:
     Type: String
     Default: manage-help-content-publisher

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,2 @@
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
 addSbtPlugin("com.github.cb372" % "sbt-explicit-dependencies" % "0.2.16")

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -3,7 +3,6 @@ stacks:
 regions:
   - eu-west-1
 deployments:
-
   cfn:
     type: cloud-formation
     app: manage-help-content-publisher

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -12,7 +12,7 @@ deployments:
   manage-help-content-publisher:
     type: aws-lambda
     parameters:
-      bucket: membership-dist
+      bucketSsmLookup: true
       fileName: manage-help-content-publisher.jar
       functionNames:
         - manage-help-content-publisher-

--- a/src/main/scala/managehelpcontentpublisher/Logging.scala
+++ b/src/main/scala/managehelpcontentpublisher/Logging.scala
@@ -1,6 +1,5 @@
 package managehelpcontentpublisher
 
-import build.BuildInfo.buildNumber
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.events.{APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent}
 import ujson.{Obj, Str}
@@ -10,7 +9,7 @@ import scala.jdk.CollectionConverters._
 object Logging {
 
   private def log(context: Context, level: String, otherFields: Obj): Unit =
-    context.getLogger.log(add(add(otherFields, "logLevel" -> level), "build" -> buildNumber).render())
+    context.getLogger.log(add(otherFields, "logLevel" -> level).render())
 
   private def logInfo(context: Context, event: String, fields: Obj): Unit =
     log(context, "INFO", add(fields, "event" -> event))


### PR DESCRIPTION
This PR sets up CI using GitHub Actions. It's now using the [Riff-Raff upload action](https://github.com/guardian/actions-riff-raff), and the deprecated `riffRaffUpload` plugin has been removed.