### PR TITLE
make snyk monitor use a better project name

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   security:
-    uses: guardian/.github/.github/workflows/sbt-node-snyk.yml@jd-projectname
+    uses: guardian/.github/.github/workflows/sbt-node-snyk.yml@main
     with:
       DEBUG: true
       ORG: the-guardian-cuu

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -8,10 +8,11 @@ on:
 
 jobs:
   security:
-    uses: guardian/.github/.github/workflows/sbt-node-snyk.yml@main
+    uses: guardian/.github/.github/workflows/sbt-node-snyk.yml@jd-projectname
     with:
       DEBUG: true
       ORG: the-guardian-cuu
       SKIP_NODE: true
+      PROJECT_FILE: build.sbt
     secrets:
        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
We discovered that since this PR https://github.com/guardian/manage-help-content-publisher/pull/474 we had a very strange project name ending in `_213`

so I did this PR https://github.com/guardian/.github/pull/71

which made it more like the happy face 
![image](https://github.com/guardian/manage-help-content-publisher/assets/7304387/fc5f451f-4b8f-4326-bc63-82515c99aca8)


This PR makes the snyk step use the new name, but we have to wait for the above PR to merge and switch back to the `main` branch again before merging this one.  Then we can do similar PRs in other repos.