### PR TITLE
Add setup-sbt step in ci action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
           java-version: '11'
           cache: 'sbt'
 
+      - name: Setup SBT
+        uses: sbt/setup-sbt@v1
+
       - name: Compile and package project
         run: sbt clean assembly
 


### PR DESCRIPTION
## What does this change?
Build has started failing with `sbt: command not found` error as sbt isn't automatically bundled with github action's latest ubuntu images.

This adds the sbt runner to the job: https://github.com/sbt/setup-sbt