### PR TITLE
Use GU setup-scala workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,8 @@ jobs:
           aws-region: eu-west-1
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
 
-      - name: Setup Java
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'corretto'
-          java-version: '11'
-          cache: 'sbt'
+      - name: Setup Java and sbt
+        uses: guardian/setup-scala@v1
 
       - name: Compile and package project
         run: sbt clean assembly

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+java corretto-11.0.25.9.1


### PR DESCRIPTION
## What does this change?
Uses the Guardian-provided [setup-scala](https://github.com/guardian/setup-scala) workflow to avoid `sbt: command not found` errors during CI builds (caused by github no longer rolling sbt with java).

 