### PR TITLE
Upgrade s3 dependency

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,6 +15,6 @@ object Dependencies {
   lazy val utest = "com.lihaoyi" %% "utest" % "0.8.1"
   lazy val awsLambda = "com.amazonaws" % "aws-lambda-java-core" % "1.2.2"
   lazy val awsEvents = "com.amazonaws" % "aws-lambda-java-events" % "3.11.1"
-  lazy val s3 = "software.amazon.awssdk" % "s3" % "2.21.11"
+  lazy val s3 = "software.amazon.awssdk" % "s3" % "2.32.19"
   lazy val slf4jNop = "org.slf4j" % "slf4j-nop" % "2.0.5"
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This upgrades `software.amazon.awssdk:s3` to the latest version, to upgrade the transitive dependency `io.netty:netty-handler` and  resolve this Dependabot alert https://github.com/guardian/manage-help-content-publisher/security/dependabot/3