### PR TITLE
Fix CVE-2026-33870

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,8 @@ import Dependencies._
 
 ThisBuild / scalaVersion := "2.13.18"
 
+ThisBuild / dependencyOverrides ++= nettyOverrides
+
 ThisBuild / scalacOptions += "-deprecation"
 
 lazy val root = (project in file("."))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,6 +3,8 @@ import sbt._
 object Dependencies {
   val circeVersion = "0.14.15"
   val upickleVersion = "4.4.3"
+  // CVE-2026-33870: HTTP Request Smuggling via Chunked Extension Quoted-String Parsing
+  val nettyVersion = "4.1.132.Final"
 
   lazy val http = "org.scalaj" %% "scalaj-http" % "2.4.2"
   lazy val ujson = "com.lihaoyi" %% "ujson" % upickleVersion
@@ -17,4 +19,17 @@ object Dependencies {
   lazy val awsEvents = "com.amazonaws" % "aws-lambda-java-events" % "3.16.1"
   lazy val s3 = "software.amazon.awssdk" % "s3" % "2.42.15"
   lazy val slf4jNop = "org.slf4j" % "slf4j-nop" % "2.0.17"
+
+  lazy val nettyOverrides: Seq[ModuleID] = Seq(
+    "io.netty" % "netty-codec-http"                    % nettyVersion,
+    "io.netty" % "netty-codec-http2"                   % nettyVersion,
+    "io.netty" % "netty-codec"                         % nettyVersion,
+    "io.netty" % "netty-transport"                     % nettyVersion,
+    "io.netty" % "netty-common"                        % nettyVersion,
+    "io.netty" % "netty-buffer"                        % nettyVersion,
+    "io.netty" % "netty-handler"                       % nettyVersion,
+    "io.netty" % "netty-resolver"                      % nettyVersion,
+    "io.netty" % "netty-transport-classes-epoll"       % nettyVersion,
+    "io.netty" % "netty-transport-native-unix-common"  % nettyVersion,
+  )
 }


### PR DESCRIPTION
## What does this change?

Upgrades all transitive Netty dependencies from `4.1.130.Final` to `4.1.132.Final` to address CVE-2026-33870, a high-severity HTTP Request Smuggling vulnerability in `io.netty:netty-codec-http`.

Netty was not a direct dependency but was pulled in transitively via `software.amazon.awssdk:netty-nio-client` (used by the S3 SDK). Because SBT does not automatically upgrade transitive dependencies beyond what the declaring library requests, the vulnerable version was silently resolved.

The fix adds a `dependencyOverrides` block in `build.sbt` that pins all Netty modules to `4.1.132.Final`, which contains the patch. The override is applied at the `ThisBuild` scope so it covers both the root project and the `legacyContentImport` sub-project.

**Vulnerability summary:** Netty incorrectly terminated chunk header parsing at `\r\n` inside a quoted-string chunk extension value, rather than rejecting the request as malformed. This parsing differential between Netty and RFC-compliant proxies/caches could be exploited to smuggle arbitrary HTTP requests, potentially enabling cache poisoning, access control bypass, and session hijacking.

## How has this change been tested?

The resolved classpath was verified via `sbt "show externalDependencyClasspath"`, confirming all 10 Netty modules (`netty-codec-http`, `netty-codec-http2`, `netty-codec`, `netty-transport`, `netty-common`, `netty-buffer`, `netty-handler`, `netty-resolver`, `netty-transport-classes-epoll`, `netty-transport-native-unix-common`) are now resolved at `4.1.132.Final`.

No functional behaviour changes are expected since this is a patch-version bump within the 4.1.x line, so the existing unit test suite is sufficient validation.

## How can we measure success?

The Dependabot alert for CVE-2026-33870 should be dismissed once this is merged. No runtime metrics are expected to change, as the fix is entirely within HTTP request parsing logic that this service does not directly exercise (Netty is used by the AWS SDK for async HTTP transport, not for serving inbound requests).

## Have we considered potential risks?

The risk of upgrading a transitive dependency is minimal: `4.1.132.Final` is a patch release on the same minor line and is API-compatible. The AWS SDK `netty-nio-client` artifact is still used unchanged, only the underlying Netty jars it depends on are overridden to the patched version. No alarms or stakeholder notifications are required.

## Images

N/A, no UI changes.

## Accessibility

N/A, no UI changes.