### PR TITLE
Fix CVE-2026-33871

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,6 +36,18 @@ lazy val legacyContentImport = (project in file("legacy-content-import"))
     )
   )
 
+// Force patched Netty version to address CVE-2026-33871 (HTTP/2 CONTINUATION frame flood DoS)
+ThisBuild / dependencyOverrides ++= Seq(
+  "io.netty" % "netty-buffer"       % nettyVersion,
+  "io.netty" % "netty-codec"        % nettyVersion,
+  "io.netty" % "netty-codec-http"   % nettyVersion,
+  "io.netty" % "netty-codec-http2"  % nettyVersion,
+  "io.netty" % "netty-common"       % nettyVersion,
+  "io.netty" % "netty-handler"      % nettyVersion,
+  "io.netty" % "netty-resolver"     % nettyVersion,
+  "io.netty" % "netty-transport"    % nettyVersion,
+)
+
 testFrameworks += new TestFramework("utest.runner.Framework")
 
 assembly / assemblyMergeStrategy := {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,6 +3,7 @@ import sbt._
 object Dependencies {
   val circeVersion = "0.14.15"
   val upickleVersion = "4.4.3"
+  val nettyVersion = "4.1.132.Final" // CVE-2026-33871: CONTINUATION frame flood DoS
 
   lazy val http = "org.scalaj" %% "scalaj-http" % "2.4.2"
   lazy val ujson = "com.lihaoyi" %% "ujson" % upickleVersion


### PR DESCRIPTION
## What does this change?

Upgrades the transitive Netty dependency from `4.1.130.Final` to `4.1.132.Final` to address CVE-2026-33871 (Netty HTTP/2 CONTINUATION Frame Flood DoS, High severity).

Netty is not a direct dependency of this project, but is pulled in transitively via `software.amazon.awssdk:netty-nio-client`, which is itself a transitive dependency of the AWS S3 SDK (`software.amazon.awssdk:s3`).

The vulnerability allows an unauthenticated remote user to flood an HTTP/2 server with CONTINUATION frames carrying zero-byte payloads. Because the existing size-based mitigation (`maxHeaderListSize`) is never triggered by zero-byte frames, the server is forced to process an unbounded number of frames, exhausting CPU and rendering it unresponsive.

The fix adds a `dependencyOverrides` block in build.sbt that forces all affected Netty modules to `4.1.132.Final` (the patched release) across both the root project and the `legacyContentImport` sub-project.

## How has this change been tested?

The dependency resolution can be verified locally by running `sbt dependencyTree` and confirming all `io.netty` modules resolve to `4.1.132.Final`. No functional behaviour is changed, as this is a dependency version bump with no API changes relevant to this project's usage.

## How can we measure success?

No Dependabot alerts for CVE-2026-33871 against this repository after the change is merged.

## Have we considered potential risks?

The upgrade is a patch-level bump within the `4.1.x` line (`4.1.130.Final` to `4.1.132.Final`), so breaking changes are not expected. The `dependencyOverrides` approach is intentionally explicit, listing each Netty module individually so future dependency updates are not silently overridden beyond what is necessary to address this CVE.

## Images

N/A, no UI changes.

## Accessibility

N/A, no UI changes.