### PR TITLE
Fix CVE-2026-33671

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "overrides": {
       "minimatch@^9": ">=9.0.7 <10",
       "minimatch@^10": ">=10.2.3",
-      "flatted": ">=3.4.0"
+      "flatted": ">=3.4.0",
+      "picomatch@^2": ">=2.3.2 <3",
+      "picomatch@^4": ">=4.0.4"
     }
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,8 @@ overrides:
   minimatch@^9: '>=9.0.7 <10'
   minimatch@^10: '>=10.2.3'
   flatted: '>=3.4.0'
+  picomatch@^2: '>=2.3.2 <3'
+  picomatch@^4: '>=4.0.4'
 
 importers:
 
@@ -1322,7 +1324,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: ^3 || ^4
+      picomatch: '>=4.0.4'
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -2117,12 +2119,12 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
 
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
   pirates@4.0.7:
@@ -3211,7 +3213,7 @@ snapshots:
       '@types/eslint': 9.6.1
       eslint: 8.57.1
       estraverse: 5.3.0
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   '@stylistic/eslint-plugin-plus@2.6.2(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
@@ -3545,7 +3547,7 @@ snapshots:
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   argparse@1.0.10:
     dependencies:
@@ -4291,9 +4293,9 @@ snapshots:
     dependencies:
       bser: 2.1.1
 
-  fdir@6.5.0(picomatch@4.0.3):
+  fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   file-entry-cache@6.0.1:
     dependencies:
@@ -4973,7 +4975,7 @@ snapshots:
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   jest-validate@29.7.0:
     dependencies:
@@ -5105,7 +5107,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   mimic-fn@2.1.0: {}
 
@@ -5263,9 +5265,9 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.1: {}
+  picomatch@2.3.2: {}
 
-  picomatch@4.0.3: {}
+  picomatch@4.0.4: {}
 
   pirates@4.0.7: {}
 
@@ -5582,8 +5584,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tmpl@1.0.5: {}
 


### PR DESCRIPTION
## What does this change?

Addresses CVE-2026-33671, a ReDoS (Regular Expression Denial of Service) vulnerability in `picomatch` affecting versions `< 2.3.2`, `>= 3.0.0 < 3.0.2`, and `>= 4.0.0 < 4.0.4`.

The vulnerability allows crafted extglob patterns (e.g. `+(a|aa)`, `+(+(a))`) to be compiled into regular expressions exhibiting catastrophic backtracking, potentially blocking the Node.js event loop for seconds on short non-matching inputs.

Two vulnerable transitive versions were present in the lockfile:
- `picomatch@2.3.1`, pulled in by `anymatch`, `jest-util`, and `micromatch`
- `picomatch@4.0.3`, pulled in by `fdir` and `tinyglobby`

Two pnpm overrides were added to package.json to force the patched versions:
- `"picomatch@^2": ">=2.3.2 <3"` , resolving to `2.3.2`
- `"picomatch@^4": ">=4.0.4"` , resolving to `4.0.4`

## How has this change been tested?

The pnpm-lock.yaml has been verified to contain no references to the vulnerable versions. All `picomatch` usages now resolve to `2.3.2` or `4.0.4`. No functional code changes were made, only dependency version constraints.

## How can we measure success?

The GitHub Dependabot alert for CVE-2026-33671 should be resolved once this change is merged. No runtime regressions are expected, as this is a patch-level version bump with no API changes.

## Have we considered potential risks?

The overrides pin to patch releases (`2.3.2` and `4.0.4`) of their respective major version lines, so the risk of breakage is very low. The `<3` upper bound on the `^2` override ensures `anymatch`, `jest-util`, and `micromatch` are not inadvertently upgraded to an incompatible major version.

## Images

N/A, no UI changes.

## Accessibility

N/A, no UI changes.

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)