### PR TITLE
Remove aws-actions/configure-aws-credentials usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,13 +57,6 @@ jobs:
 
       - name: Compile and package Lambda
         run: sbt clean assembly
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-          aws-region: eu-west-1
-
       - uses: guardian/actions-riff-raff@v4
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Removes workflow steps using aws-actions/configure-aws-credentials.\

v4 and above of riff raff upload action handles the required credentials internally.  These credentials fetches are no longer required.  For security purposes, we would prefer not to have unused credentials anywhere. 